### PR TITLE
changes around importing Julia packages/modules

### DIFF
--- a/JuliaExperimental/gap/utils.gi
+++ b/JuliaExperimental/gap/utils.gi
@@ -39,59 +39,10 @@ InstallMethod( ConvertedToJulia,
 
 #############################################################################
 ##
-#! @Arguments pkgname
-#! @Returns <K>true</K> or <K>false</K>.
-#! @Description
-#!  This function triggers the execution of a <C>using</C> statement
-#!  for the Julia package with name <A>pkgname</A>.
-#!  It returns <K>true</K> if the call was successful,
-#!  and <K>false</K> otherwise.
-#!  <P/>
-#!  Apparently <C>libjulia</C> throws an error
-#!  when trying to compile the package, which happens when some files from
-#!  the package have been modified since compilation.
-#!  <P/>
-#!  Thus &GAP; has to check whether the Julia package has been loaded
-#!  successfully, and can then load and execute code that relies on this
-#!  Julia package.
-#!  In particular, we cannot just put the necessary <C>using</C> statements
-#!  into the relevant <F>.jl</F> files,
-#!  and then load these files with <Ref Func="JuliaIncludeFile"/>.
-BindGlobal( "JuliaUsingPackage", function( pkgname )
-    local was_successful, julia_path;
-    if not IsString( pkgname ) then
-        Error( "<pkgname> must be a string, the name of a Julia package" );
-    fi;
-    was_successful := ConvertedFromJulia( JuliaEvalString( Concatenation(
-             "try\nusing ", pkgname,
-             "\nreturn true\ncatch e\nreturn e\nend" ) ) );
-    if was_successful = true then
-        return true;
-    else
-        #Try to compile package by loading it into external Julia
-        #Get Julia path
-        julia_path := ConvertedFromJulia( JuliaEvalString( "JULIA_HOME" ) );
-        Exec( Concatenation( julia_path, "/../bin/julia -e \"using ", pkgname, "\"" ) );
-    fi;
-    # Try the same again. If it fails this time, we are out
-    if ConvertedFromJulia( JuliaEvalString( Concatenation(
-             "try\nusing ", pkgname,
-             "\nreturn true\ncatch e\nreturn e\nend" ) ) ) = true then
-      return true;
-    else
-      Info( InfoWarning, 1,
-            "The Julia package '", pkgname, "' cannot be loaded" );
-      return false;
-    fi;
-    end );
-
-
-#############################################################################
-##
 #! @Arguments juliaobj
 #! @Returns a string.
 #! @Description
-#!  Returns the string that describes the julia type of the Julia object
+#!  Returns the string that describes the julia type of the &Julia; object
 #!  <A>juliaobj</A>.
 BindGlobal( "JuliaTypeInfo",
     juliaobj -> ConvertedFromJulia( Julia.Base.string(
@@ -105,11 +56,11 @@ BindGlobal( "JuliaTypeInfo",
 ##
 ##  'Julia_time' measures the wall clock time between the start and the end
 ##  of the computations;
-##  this includes both the &GAP; and the Julia computations.
+##  this includes both the &GAP; and the &Julia; computations.
 ##
 ##  'GAP_time' measures the &GAP; runtime of the computations;
 ##  this does apparently include most of the time needed by computations
-##  in Julia, but for example *not* times spent in <C>sleep</C> calls.
+##  in &Julia;, but for example *not* times spent in <C>sleep</C> calls.
 ##
 ##  Try to understand better how this works!
 ##
@@ -141,7 +92,7 @@ BindGlobal( "CallFuncListWithTimings", function( func, args )
 #F  JuliaArrayOfFmpz( <coeffs> )
 ##
 ##  For a list <A>coeffs</A> of integers, this function creates
-##  a Julia array that contains the corresponding Julia objects of type
+##  a &Julia; array that contains the corresponding &Julia; objects of type
 ##  <C>fmpz</C>.
 ##
 BindGlobal( "JuliaArrayOfFmpz", function( coeffs )
@@ -172,7 +123,7 @@ BindGlobal( "JuliaArrayOfFmpz", function( coeffs )
 #F  JuliaArrayOfFmpq( <coeffs> )
 ##
 ##  For a list <A>coeffs</A> of rationals, this function creates
-##  a Julia array that contains the corresponding Julia objects of type
+##  a &Julia; array that contains the corresponding &Julia; objects of type
 ##  <C>fmpq</C>.
 ##
 BindGlobal( "JuliaArrayOfFmpq", function( coeffs )

--- a/JuliaExperimental/read.g
+++ b/JuliaExperimental/read.g
@@ -24,7 +24,7 @@ ReadPackage( "JuliaExperimental", "gap/zlattice.g");
 
 
 # Use Julia to compute the HNF of an integer matrix.
-if JuliaUsingPackage( "Nemo" ) then
+if JuliaImportPackage( "Nemo" ) then
   ReadPackage( "JuliaExperimental", "gap/hnf.g");
 fi;
 
@@ -38,19 +38,19 @@ ReadPackage( "JuliaExperimental", "gap/gapperm.g");
 
 
 # Nemo's number fields.
-if JuliaUsingPackage( "Nemo" ) then
+if JuliaImportPackage( "Nemo" ) then
   ReadPackage( "JuliaExperimental", "gap/numfield.g");
 fi;
 
 
 # Arb
-if JuliaUsingPackage( "Nemo" ) then
+if JuliaImportPackage( "Nemo" ) then
   ReadPackage( "JuliaExperimental", "gap/realcyc.g");
 fi;
 
 
 # Singular
-if JuliaUsingPackage( "Singular" ) then
+if JuliaImportPackage( "Singular" ) then
   ReadPackage( "JuliaExperimental", "gap/singular.g");
 fi;
 

--- a/JuliaExperimental/tst/utils.tst
+++ b/JuliaExperimental/tst/utils.tst
@@ -5,13 +5,6 @@
 gap> START_TEST( "utils.tst" );
 
 ##
-gap> JuliaUsingPackage( "Core" );
-true
-gap> JuliaUsingPackage( "No_Julia_Package_With_This_Name" );
-#I  The Julia package 'No_Julia_Package_With_This_Name' cannot be loaded
-false
-
-##
 gap> JuliaTypeInfo( 0 );
 "Int64"
 gap> JuliaTypeInfo( ConvertedToJulia( 1 ) );

--- a/JuliaInterface/gap/JuliaInterface.gd
+++ b/JuliaInterface/gap/JuliaInterface.gd
@@ -155,4 +155,44 @@ InstallGlobalFunction( GetJuliaObj,
     return Julia.(module_name).(julia_name);
 end );
 
+
+#! @Arguments pkgname
+#! @Returns <K>true</K> or <K>false</K>.
+#! @Description
+#!  This function triggers the execution of an <C>import</C> statement
+#!  for the &Julia; package with name <A>pkgname</A>.
+#!  It returns <K>true</K> if the call was successful,
+#!  and <K>false</K> otherwise.
+#!  <P/>
+#!  Note that we just want to load the package into &Julia;,
+#!  we do <E>not</E> want to import variable names from the package
+#!  into &Julia;'s <C>Main</C> module, because the &Julia; variables must be
+#!  referenced relative to their modules if we want to be sure to access
+#!  the correct values.
+#!  <P/>
+#!  Why is this function needed?
+#!  <P/>
+#!  Apparently <C>libjulia</C> throws an error
+#!  when trying to compile the package, which happens when some files from
+#!  the package have been modified since compilation.
+#!  <P/>
+#!  Thus &GAP; has to check whether the &Julia; package has been loaded
+#!  successfully, and can then safely load and execute code
+#!  that relies on this &Julia; package.
+#!  In particular, we cannot just put the necessary <C>import</C> statements
+#!  into the relevant <F>.jl</F> files,
+#!  and then load these files with <Ref Func="JuliaIncludeFile"/>.
+DeclareGlobalFunction( "JuliaImportPackage" );
+
+
+#! @Arguments name
+#! @Returns nothing.
+#! @Description
+#!  The aim of this function is to make those global variables
+#!  that are exported by the &Julia; module with name <A>name</A>
+#!  available in the global record <C>Julia</C>.
+#!  After the call, the <A>name</A> component of this record will be bound
+#!  to a record that contains the variables from the &Julia; module.
 DeclareGlobalFunction( "ImportJuliaModuleIntoGAP" );
+
+

--- a/JuliaInterface/tst/convert.tst
+++ b/JuliaInterface/tst/convert.tst
@@ -1,5 +1,5 @@
 ##
-gap> START_TEST( "box_unbox.tst" );
+gap> START_TEST( "convert.tst" );
 
 ##
 gap> int := ConvertedToJulia( 11 );
@@ -49,5 +49,5 @@ gap> List( list2, ConvertedFromJulia );
 [ 1, fail, 3 ]
 
 ##
-gap> STOP_TEST( "box_unbox.tst", 1 );
+gap> STOP_TEST( "convert.tst", 1 );
 

--- a/JuliaInterface/tst/import.tst
+++ b/JuliaInterface/tst/import.tst
@@ -1,0 +1,18 @@
+##
+gap> START_TEST( "import.tst" );
+
+##
+gap> JuliaImportPackage( "Core" );
+true
+gap> JuliaImportPackage( "No_Julia_Package_With_This_Name" );
+#I  The Julia package 'No_Julia_Package_With_This_Name' cannot be loaded.
+false
+
+##
+gap> ImportJuliaModuleIntoGAP( "Core" );
+gap> ImportJuliaModuleIntoGAP( "No_Julia_Module_With_This_Name" );
+#I  The Julia module 'No_Julia_Module_With_This_Name' cannot be imported.
+
+##
+gap> STOP_TEST( "import.tst", 1 );
+


### PR DESCRIPTION
- renamed `JuliaUsingPackage` to `JuliaImportPackage`,
  changed it to use try/catch also in the command line argument for Julia,
  moved it from JuliaExperimental to JuliaInterface;
- added documentation to `ImportJuliaModuleIntoGAP`;
- in `ImportJuliaModuleIntoGAP`, catch the case that the module cannot
  be imported;
- added a testfile `tst/import.tst` for the two import functions;
- changed Julia to &Julia; in some places.