### PR TITLE
support converting Nemo polynomials to GAP

### DIFF
--- a/JuliaExperimental/gap/record.g
+++ b/JuliaExperimental/gap/record.g
@@ -14,7 +14,7 @@
 #! @Returns a &Julia; object
 #! @Description
 #!  For a record <A>arec</A>,
-#!  this function creates a dictionary in Julia
+#!  this function creates a dictionary in &Julia;
 #!  whose components are the record components of <A>arec</A>,
 #!  and the corresponding 
 InstallMethod( ConvertedToJulia,

--- a/JuliaExperimental/ipynb/GAPJulia_Singular_blog.ipynb
+++ b/JuliaExperimental/ipynb/GAPJulia_Singular_blog.ipynb
@@ -466,8 +466,7 @@
     }
    ],
    "source": [
-    "# Currently there is no 'Julia.Singular.Matrix'.\n",
-    "JuliaFunction( \"Matrix\", \"Singular\" )( M );"
+    "Julia.Singular.Matrix( M );"
    ]
   },
   {

--- a/JuliaExperimental/julia/hnf.jl
+++ b/JuliaExperimental/julia/hnf.jl
@@ -9,7 +9,7 @@ using Nemo
 
 export unpackedNemoMatrixFmpz
 
-function fitsGAPSmallIntRep( x::fmpz )
+function fitsGAPSmallIntRep( x::Nemo.fmpz )
     return -2^60 <= x && x < 2^60
 end
 

--- a/JuliaExperimental/julia/numfield.jl
+++ b/JuliaExperimental/julia/numfield.jl
@@ -12,25 +12,33 @@ import Base: length, similar, zeros, ==, isless, *, one, inv, ^, /
 using Nemo
 # using Hecke
 
-export MatrixFromNestedArray, Nemo_Matrix_over_NumberField,
+export NemoElementOfNumberField,
+       Nemo_Matrix_over_NumberField,
        CoefficientVectorsNumDenOfNumberFieldElement,
        MatricesOfCoefficientVectorsNumDen
 
 # export ConvertedToJulia_Cyclotomics
 
 
-##  Turn a nested 1-dim. array (as created by 'ConvertedToJulia'
-##  into a 2-dim. array
+doc"""
+    NemoElementOfNumberField( f, lst, denom )
+> Return the element in the number field `f` for which `lst` is the array
+> of numerators of the coefficients w.r.t. the defining polynomial of `f`,
+> and `denom` is the common denominator.
+"""
+function NemoElementOfNumberField( f, lst, denom::Int )
+    return Nemo.elem_from_mat_row( f, lst, 1, Nemo.fmpz( denom ) )
+end
 
-function MatrixFromNestedArray( lst ) return hcat( lst... )' end
 
-
-##  Create an 'm' by 'n' matrix of elements in the field 'f'
-##  from a list 'lst' (of length 'm' times 'n')
-##  of integer coefficient vectors,
-##  for which 'denom' is the common denominator.
-
-function Nemo_Matrix_over_NumberField( f, m, n, lst, denom )
+doc"""
+    Nemo_Matrix_over_NumberField( f, m, n, lst, denom )
+> Return an `m` by `n` matrix of elements in the Nemo number field `f`
+> from the list `lst` (which has length `m` times `n`)
+> of integer coefficient vectors,
+> for which `denom` is the common denominator.
+"""
+function Nemo_Matrix_over_NumberField( f, m::Int, n::Int, lst, denom::Int )
     local pos, mat, d, i, j
 
     pos = 1
@@ -48,10 +56,12 @@ function Nemo_Matrix_over_NumberField( f, m, n, lst, denom )
 end
 
 
-##  Create the coefficient vector of the element `elm`,
-##  as an array of length `d` and consisting of `fmpq` objects.
-
-function CoefficientVectorOfNumberFieldElement( elm, d )
+doc"""
+    CoefficientVectorOfNumberFieldElement( elm::Nemo.nf_elem, d::Int )
+> Return the coefficient vector of the number field element `elm`,
+> as an array of length `d` and consisting of `Nemo.fmpq` objects.
+"""
+function CoefficientVectorOfNumberFieldElement( elm::Nemo.nf_elem, d::Int )
     local arr, i
 
     arr = Array{Nemo.fmpq,1}( d )
@@ -63,26 +73,34 @@ function CoefficientVectorOfNumberFieldElement( elm, d )
 end
 
 
-##  Create the vectors for numerator and denominator
-##  of the coefficient vector of the element `elm`,
-##  as arrays of length `d` and consisting of `fmpz` objects.
-
+doc"""
+    CoefficientVectorsNumDenOfNumberFieldElement( elm::Nemo.nf_elem, d::Int )
+> Return the tuple that consists of the coefficient vectors
+> of the numerators and the denominators of the coefficient vector
+> of the number field element `elm`,
+> as arrays of length `d` and consisting of `Nemo.fmpz` objects.
+"""
 function CoefficientVectorsNumDenOfNumberFieldElement( elm, d )
-    local num, den, i
+    local num, den, i, onecoeff
 
     num = Array{Nemo.fmpz,1}( d )
     den = Array{Nemo.fmpz,1}( d )
     for i = 1:d
-      num[i] = numerator( Nemo.coeff( elm, i-1 ) )
-      den[i] = denominator( Nemo.coeff( elm, i-1 ) )
+      onecoeff = Nemo.coeff( elm, i-1 )
+      num[i] = numerator( onecoeff )
+      den[i] = denominator( onecoeff )
     end
 
     return num, den
 end
 
 
-##  2-dim. (m n) times d arrays of Nemo.fmpz elements
-
+doc"""
+    MatricesOfCoefficientVectorsNumDen( nemomat, d )
+> Return the tuple that consists of two 2-dim. (m n) times `d` arrays
+> of `Nemo.fmpz` objects that describe the numerators and the denominators
+> of the number field elements in the matrix `nemomat`.
+"""
 function MatricesOfCoefficientVectorsNumDen( nemomat, d )
     local m, n, num, den, i, j, resnum, resden
 
@@ -104,19 +122,20 @@ end
 
 
 #T as soon as 'Qab.jl' is officially available in Hecke:
-# ##  Translate between GAP's cyclotomics and Hecke's QabElem objects.
-# ##  'lst' is a list of integral coefficient vectors w.r.t.
-# ##  the 'N'-th cyclotomic field,
-# ##  'denom' is the common denominator.
-# ##
-# ##  The result is an array of field elements.
-# 
+# doc"""
+#     ConvertedToJulia_Cyclotomics( N, lst, denom )
+# > Return an array of n `QabElem` objects,
+# > which correspond to the n entries of the array `lst`.
+# > Each entry is the vector of numerators of the coefficient vector
+# > of an element in the `N`-th cyclotomic field,
+# > and `denom` is the common denominator.
+# """
 # ConvertedToJulia_Cyclotomics = function( N, lst, denom )
 #     local f, x, n, m, mat, d, res
 # 
 #     f, x = Nemo.CyclotomicField( N, "x" )
 #     n = length( lst )
-#     m = MatrixSpace( ZZ, n, length( lst[1] ) )
+#     m = MatrixSpace( Nemo.ZZ, n, length( lst[1] ) )
 #     mat = m( hcat( lst... )' )
 #     d = Nemo.fmpz( denom )
 #     res = Array{Any}( n )

--- a/JuliaExperimental/julia/utils.jl
+++ b/JuliaExperimental/julia/utils.jl
@@ -7,7 +7,10 @@
 
 module GAPUtilsExperimental
 
-export MatrixFromNestedArray
+import Nemo
+
+export MatrixFromNestedArray, CoefficientsNumDenOfNemoPolynomialFmpq,
+       JuliaSourceFile
 
 doc"""
     MatrixFromNestedArray( lst )
@@ -15,6 +18,72 @@ doc"""
 > (Note that GAP's `ConvertedToJulia` creates nested arrays.)
 """
 function MatrixFromNestedArray( lst ) return hcat( lst... )' end
+
+
+doc"""
+    fitsGAPSmallIntRep( x::Nemo.fmpz )
+> Return `true` if `x` corresponds to a GAP integer in `IsSmallIntRep`,
+> and `false`otherwise.
+"""
+function fitsGAPSmallIntRep( x::Nemo.fmpz )
+    return -2^60 <= x && x < 2^60
+end
+
+
+function CoefficientsOfUnivarateNemoPolynomialFmpq( pol::Nemo.fmpq_poly )
+    return map( i -> Nemo.coeff( pol, i ), 0:(length(pol)-1) )
+end
+
+
+function NestedArrayFromMatrix( mat )
+    return map( i -> mat[i,:], 1:size(mat,1) )
+end
+
+
+doc"""
+    CoefficientsNumDenOfFmpqArray( arr::Array{Nemo.fmpq,1}[, tryint::Bool = true] )
+> Return a tuple `(<kind>, <arrnum>, <arrden>)` where <arrnum>, <arrden>
+> are 1-dim. arrays of the numerators and denominators of the values in <arr>,
+> and <kind> is either `"int"` (the entries are small integers)
+> or `"string"` (the entries are hex strings).
+> This format is suitable for calling `ConvertedFromJulia` from GAP.
+"""
+function CoefficientsNumDenOfFmpqArray( arr::Array{Nemo.fmpq,1}, tryint::Bool = true )
+    n = length( arr )
+    coeffsnum = map( i -> numerator( arr[i] ), 1:n )
+    coeffsden = map( i -> denominator( arr[i] ), 1:n )
+
+    if tryint == true
+      # Check whether the entries are small enough for being unboxed
+      # to small integers in GAP, i. e., in the range '[ -2^60 .. 2^60-1 ]'.
+      fits = [ fitsGAPSmallIntRep( coeffsnum[i] ) for i in 1:n ]
+      if all( [ fitsGAPSmallIntRep( coeffsnum[i] ) for i in 1:n ] ) &&
+         all( [ fitsGAPSmallIntRep( coeffsden[i] ) for i in 1:n ] )
+        return ( "int", map( Int, coeffsnum ), map( Int, coeffsden ) )
+      end
+    end
+
+    # Either we *want* to create a nested array of strings,
+    # or some entry is too large.
+    # Turn the 2-dim. array into a 1-dim. array of 1-dim. arrays
+    # (which can then be unboxed with 'ConvertedFromJulia').
+    return ( "string", [ hex( coeffsnum[i] ) for i in 1:n ],
+                       [ hex( coeffsden[i] ) for i in 1:n ] )
+end
+
+doc"""
+    JuliaSourceFile( func, types )
+> Return the tuple `( filename, startline )`
+> such that the source code of the method `func`
+> that expects arguments of the types given in the tuple `types`
+> can be found in the file `filename`, starting at line `startline`.
+"""
+function JuliaSourceFile( func, types )
+    local meth::Method
+
+    meth = which( func, types )
+    return ( string( meth.file ), meth.line )
+end
 
 end
 

--- a/JuliaExperimental/julia/zlattice.jl
+++ b/JuliaExperimental/julia/zlattice.jl
@@ -18,7 +18,6 @@ export LLLReducedGramMat, ShortestVectors, OrthogonalEmbeddings
 doc"""
     LLLReducedGramMat( grammatrix::Array{Int,2}, y::Rational{Int} = 3//4 )
 > Return a dictionary with the following components.
->   remainder`
 >   `remainder`:      the reduced Gram matrix (`Array{Rational{Int},2}`)
 >   `relations`:      basechange matrix `H` (`Array{Rational{Int},2}`)
 >   `transformation`: basechange matrix `H` (`Array{Rational{Int},2}`)
@@ -470,6 +469,10 @@ end
 
 # A = [ 2 -1 -1 -1 ; -1 2 0 0 ; -1 0 2 0 ; -1 0 0 2 ];
 
+doc"""
+    OrthogonalEmbeddings( A::Array{Int,2}, arec::Dict )
+> ...
+"""
 function OrthogonalEmbeddings( A::Array{Int,2}, arec::Dict )
 
     local ExtendAtPosition,

--- a/JuliaExperimental/tst/numfield.tst
+++ b/JuliaExperimental/tst/numfield.tst
@@ -20,6 +20,27 @@ gap> Nemo_Polynomial( R, [ [ 1, 2, 3 ], [ [ 4, 5, 6 ], [ 7, 8, 9 ] ] ] );
 gap> Nemo_Polynomial( R, [ [ 1, 2, 3/2 ], [ [ 4, 5, 6 ], [ 7, 8, 9 ] ] ] );
 <<Julia: x^4*y^7+2*x^5*y^8+3//2*x^6*y^9>>
 
+# polynomial arithmetics?
+
+# Nemo number fields
+gap> x:= X( Rationals );;
+gap> f:= AlgebraicExtension( Rationals, x^2+1 );;
+gap> iso:= IsomorphismToNemoField( f );;
+gap> ff:= Range( iso );
+<field in characteristic 0>
+gap> one:= Image( iso, One( f ) );
+<<Julia: 1>>
+gap> PreImage( iso, one );
+!1
+gap> a:= RootOfDefiningPolynomial( f );
+a
+gap> gen:= Image( iso, a );
+<<Julia: a>>
+gap> PreImage( iso, gen );
+a
+
+# Arithmetic operations in number fields? (which methods get called?)
+
 # matrix over Z
 gap> mat:= NemoMatrix( Nemo_ZZ, IdentityMat( 2 ) );
 <<Julia: [1 0]
@@ -40,6 +61,11 @@ gap> mat:= [ [ o, a/2 ], [ z, o ] ];
 gap> nmat:= NemoMatrix( ff, mat );
 <<Julia: [1 1//2*a]
 [0 1]>>
+gap> PrintObj( nmat );
+[1 1//2*a]
+[0 1]
+gap> TraceMat( nmat );
+<<Julia: 2>>
 gap> GAPMatrix( f, nmat );
 [ [ !1, 1/2*a ], [ !0, !1 ] ]
 gap> no:= One( ff );


### PR DESCRIPTION
- added new GAP functions `GAPCoefficientsOfNemo_Polynomial`,
  `ElementOfNemoNumberField`,
  and corresponding Julia functions

- increase the rank of generic methods for `IsNemoObject` arguments,
  otherwise the GAP library methods for polynomials are preferred

- simplified syntax:
  now `Julia.Singular.Matrix` and `Julia.Core._apply` are available