### PR TITLE
Change some INTOBJ_INT uses

### DIFF
--- a/JuliaInterface/src/JuliaInterface.c
+++ b/JuliaInterface/src/JuliaInterface.c
@@ -208,10 +208,10 @@ Obj __ConvertedFromJulia_internal( jl_value_t* julia_obj )
 
     // small int
     if(jl_typeis(julia_obj, jl_int64_type)){
-        return INTOBJ_INT( jl_unbox_int64( julia_obj ) );
+        return ObjInt_Int8( jl_unbox_int64( julia_obj ) );
     }
     if(jl_typeis(julia_obj, jl_int32_type)){
-        return INTOBJ_INT( jl_unbox_int32( julia_obj ) );
+        return ObjInt_Int( jl_unbox_int32( julia_obj ) );
     }
     if(jl_typeis(julia_obj, jl_int16_type)){
         return INTOBJ_INT( jl_unbox_int16( julia_obj ) );
@@ -220,10 +220,10 @@ Obj __ConvertedFromJulia_internal( jl_value_t* julia_obj )
         return INTOBJ_INT( jl_unbox_int8( julia_obj ) );
     }
     if(jl_typeis(julia_obj, jl_uint64_type)){
-        return INTOBJ_INT( jl_unbox_uint64( julia_obj ) );
+        return ObjInt_UInt8( jl_unbox_uint64( julia_obj ) );
     }
     if(jl_typeis(julia_obj, jl_uint32_type)){
-        return INTOBJ_INT( jl_unbox_uint32( julia_obj ) );
+        return ObjInt_UInt( jl_unbox_uint32( julia_obj ) );
     }
     if(jl_typeis(julia_obj, jl_uint16_type)){
         return INTOBJ_INT( jl_unbox_uint16( julia_obj ) );

--- a/JuliaInterface/src/gap_macros.c
+++ b/JuliaInterface/src/gap_macros.c
@@ -70,8 +70,8 @@ Obj MakeGapArgList( int length, Obj* array )
 
 Obj create_rational( int numerator, int denominator )
 {
-    Obj numerator_obj = INTOBJ_INT( numerator );
-    Obj denominator_obj = INTOBJ_INT( denominator );
+    Obj numerator_obj = ObjInt_Int( numerator );
+    Obj denominator_obj = ObjInt_Int( denominator );
 
     Obj rational_obj = NewBag( T_RAT, 2 * sizeof(Obj) );
 
@@ -122,8 +122,9 @@ jl_value_t* julia_gap(Obj obj)
 
 Obj gap_julia(jl_value_t* julia_obj)
 {
-    if(jl_typeis(julia_obj,jl_int64_type))
-        return INTOBJ_INT(jl_unbox_int64(julia_obj));
+    if(jl_typeis(julia_obj,jl_int64_type)) {
+        return ObjInt_Int8(jl_unbox_int64(julia_obj));
+    }
     return (Obj)(julia_obj);
 }
 


### PR DESCRIPTION
Instead use ObjInt_Int8, ObjInt_UInt8 etc. to deal with potential overflows:
not all 64 bit values fit into a GAP immediate integers; and of course on 32bit
systems things are different again

That said, I am not even sure Julia works in 32bit mode? In that case, the changes for (u)int32_t are not needed, and I would recommend adding a `static_assert` somewhere for rejecting builds against a 32bit GAP.