### PR TITLE
Fast functions

### DIFF
--- a/JuliaInterface/gap/JuliaInterface.gi
+++ b/JuliaInterface/gap/JuliaInterface.gi
@@ -40,34 +40,6 @@ InstallMethod( ConvertedToJulia,
     return result;
 end );
 
-InstallMethod( CallFuncList,
-               [ IsJuliaFunction, IsList ],
-
-  function( julia_func, argument_list )
-
-    if Length( argument_list ) = 0 then
-
-        return _JuliaCallFunc0Arg( julia_func );
-
-    elif Length( argument_list ) = 1 then
-
-        return _JuliaCallFunc1Arg( julia_func, ConvertedToJulia( argument_list[ 1 ] ) );
-
-    elif Length( argument_list ) = 2 then
-
-        return _JuliaCallFunc2Arg( julia_func, ConvertedToJulia( argument_list[ 1 ] ), ConvertedToJulia( argument_list[ 2 ] ) );
-
-    elif Length( argument_list ) = 3 then
-
-        return _JuliaCallFunc3Arg( julia_func, ConvertedToJulia( argument_list[ 1 ] ), ConvertedToJulia( argument_list[ 2 ] ), ConvertedToJulia( argument_list[ 3 ] ) );
-
-    fi;
-
-    return _JuliaCallFuncXArg( julia_func, List( argument_list, ConvertedToJulia ) );
-
-end );
-
-
 ##
 ##  We want to use &GAP's function call syntax also for certain Julia objects
 ##  that are <E>not</E> functions, for example for types such as <C>fmpz</C>.

--- a/JuliaInterface/src/JuliaInterface.h
+++ b/JuliaInterface/src/JuliaInterface.h
@@ -32,23 +32,11 @@ JULIAINTERFACE_EXCEPTION_HANDLER\
 
 // Internal Julia access functions
 
-// SET_JULIA_FUNC(o,f)
-//
-// Sets the value of the julia function GAP object
-// to the julia function pointer f.
-void SET_JULIA_FUNC(Obj, jl_function_t*);
-
 // SET_JULIA_OBJ(o,v)
 //
 // Sets the value of the julia object GAP object
 // to the julia value pointer v.
 void SET_JULIA_OBJ(Obj, jl_value_t*);
-
-// GET_JULIA_FUNC(o)
-//
-// Returns the julia function pointer
-// from the julia function GAP object o.
-jl_function_t* GET_JULIA_FUNC(Obj);
 
 // GET_JULIA_OBJ(o)
 //
@@ -62,18 +50,12 @@ Obj JuliaFunctionTypeFunc(Obj);
 // Internal
 Obj JuliaObjectTypeFunc(Obj);
 
-// IS_JULIA_FUNC(o)
-//
-// Checks if o is a julia function GAP object.
-#define IS_JULIA_FUNC(o) (TNUM_OBJ(o) == T_JULIA_FUNC)
-
 // IS_JULIA_OBJ(o)
 //
 // Checks if o is a julia object GAP object.
 #define IS_JULIA_OBJ(o) (TNUM_OBJ(o) == T_JULIA_OBJ)
 
 // Internal
-UInt T_JULIA_FUNC = 0;
 UInt T_JULIA_OBJ = 0;
 
 // NewJuliaFunc(f)
@@ -98,36 +80,6 @@ Obj Func_JuliaFunction( Obj self, Obj string );
 // Returns the function with name <function_name> from
 // the Julia module with name <module_name>.
 Obj Func_JuliaFunctionByModule( Obj self, Obj function_name, Obj module_name );
-
-// Func_JuliaCallFunc0Arg( NULL, func )
-//
-// Calls the function in the julia function GAP object <func>
-// without arguments.
-Obj Func_JuliaCallFunc0Arg( Obj self, Obj func );
-
-// Func_JuliaCallFunc1Arg( NULL, func, arg )
-//
-// Calls the function in the julia function GAP object <func>
-// on the julia object GAP object <arg>.
-Obj Func_JuliaCallFunc1Arg( Obj self, Obj func, Obj arg );
-
-// Func_JuliaCallFunc2Arg( NULL, func, arg1, arg2 )
-//
-// Calls the function in the julia function GAP object <func>
-// on the julia object GAP objecta <arg1> and <arg2>.
-Obj Func_JuliaCallFunc2Arg( Obj self, Obj func, Obj arg1, Obj arg2 );
-
-// Func_JuliaCallFunc3Arg( NULL, func, arg1, arg2, arg3 )
-//
-// Calls the function in the julia function GAP object <func>
-// on the julia object GAP object <arg1>, <arg2>, and <arg3>.
-Obj Func_JuliaCallFunc3Arg( Obj self, Obj func, Obj arg1, Obj arg2, Obj arg3 );
-
-// Func_JuliaCallFuncXArg( NULL, func, args )
-//
-// Calls the function in the julia function GAP object <func>
-// on the julia object GAP objects in the GAP plain list <args>.
-Obj Func_JuliaCallFuncXArg( Obj self, Obj func, Obj args );
 
 // FuncJuliaEvalString( NULL, string )
 //

--- a/JuliaInterface/src/JuliaInterface.h
+++ b/JuliaInterface/src/JuliaInterface.h
@@ -58,11 +58,11 @@ Obj JuliaObjectTypeFunc(Obj);
 // Internal
 UInt T_JULIA_OBJ = 0;
 
-// NewJuliaFunc(f)
+// NewJuliaFunc(f,autoConvert)
 //
 // Creates a new julia function GAP object
 // from the julia function pointer f.
-Obj NewJuliaFunc(jl_function_t*);
+Obj NewJuliaFunc(jl_function_t* f, int autoConvert);
 
 // NewJuliaObj(v)
 //


### PR DESCRIPTION
Resolves #26

Consider this Julia file:
```julia
module Stuff

import Main.ForeignGAP: MPtr

function myfunc( a::MPtr, b::MPtr )
    return a;
end

function myfunc( a::MPtr, b::Int64 )
    return a;
end

function myfunc( a::Int64, b::MPtr )
    return a;
end

function myfunc( a::Int64, b::Int64 )
    return a;
end

end

function blafunc(a, b)
    return a
end
```

Then on the GAP side, I load them using this (`_JuliaFunctionByModuleNoConv` and `_JuliaFunctionNoConv` are added by this PR):
```gap
JuliaIncludeFile( "stuff.jl" );
if not IsBound(_JuliaFunctionByModuleNoConv) then
  _JuliaFunctionByModuleNoConv:= _JuliaFunctionByModule;
  _JuliaFunctionNoConv:= _JuliaFunction;
fi;

myfunc := JuliaFunction("myfunc", "Stuff");
myfuncNoConv := _JuliaFunctionByModuleNoConv("myfunc", "Stuff");
myfuncC := JuliaBindCFunction( "Stuff.myfunc", 2, ["a", "b"] );

blafunc := JuliaFunction("blafunc");
blafuncNoConv := _JuliaFunctionNoConv("blafunc");
blafuncC := JuliaBindCFunction( "blafunc", 2, ["a", "b"] );
```

Then run some benchmarks, comparing them against a native GAP function, as well as the kernel function `ReturnFirst`

Before this PR:
```
gap> GASMAN("collect"); ListX([1..10^5], [1..10], {i,j} -> i);; time;
365
gap> GASMAN("collect"); ListX([1..10^5], [1..10], ReturnFirst);; time;
296
gap> GASMAN("collect"); ListX([1..10^5], [1..10], myfunc);; time;
2821
gap> GASMAN("collect"); ListX([1..10^5], [1..10], blafunc);; time;
3275
gap> GASMAN("collect"); ListX([1..10^5], [1..10], myfuncC);; time;
1803
gap> GASMAN("collect"); ListX([1..10^5], [1..10], blafuncC);; time;
1695
gap>
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], {i,j} -> i);; time;
293
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], ReturnFirst);; time;
288
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], myfunc);; time;
1888
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], blafunc);; time;
2047
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], myfuncC);; time;
1679
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], blafuncC);; time;
1578
gap>
gap> input:=ListWithIdenticalEntries(10^5,fail);;
gap> GASMAN("collect"); ListX("0123456789", input, {i,j} -> i);; time;
371
gap> GASMAN("collect"); ListX("0123456789", input, ReturnFirst);; time;
268
gap> GASMAN("collect"); ListX("0123456789", input, myfunc);; time;
1844
gap> GASMAN("collect"); ListX("0123456789", input, blafunc);; time;
1954
gap> GASMAN("collect"); ListX("0123456789", input, myfuncC);; time;
1447
gap> GASMAN("collect"); ListX("0123456789", input, blafuncC);; time;
1483
```

With this PR:
```
gap> GASMAN("collect"); ListX([1..10^5], [1..10], {i,j} -> i);; time;
252
gap> GASMAN("collect"); ListX([1..10^5], [1..10], ReturnFirst);; time;
271
gap> GASMAN("collect"); ListX([1..10^5], [1..10], myfunc);; time;
816
gap> GASMAN("collect"); ListX([1..10^5], [1..10], blafunc);; time;
863
gap> GASMAN("collect"); ListX([1..10^5], [1..10], myfuncC);; time;
1685
gap> GASMAN("collect"); ListX([1..10^5], [1..10], blafuncC);; time;
1748
gap> GASMAN("collect"); ListX([1..10^5], [1..10], myfuncNoConv);; time;
869
gap> GASMAN("collect"); ListX([1..10^5], [1..10], blafuncNoConv);; time;
873
gap>
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], {i,j} -> i);; time;
285
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], ReturnFirst);; time;
261
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], myfunc);; time;
284
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], blafunc);; time;
299
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], myfuncC);; time;
1559
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], blafuncC);; time;
1626
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], myfuncNoConv);; time;
278
gap> GASMAN("collect"); ListX("0123456789", [1..10^5], blafuncNoConv);; time;
277
gap>
gap> input:=ListWithIdenticalEntries(10^5,fail);;
gap> GASMAN("collect"); ListX("0123456789", input, {i,j} -> i);; time;
357
gap> GASMAN("collect"); ListX("0123456789", input, ReturnFirst);; time;
271
gap> GASMAN("collect"); ListX("0123456789", input, myfunc);; time;
272
gap> GASMAN("collect"); ListX("0123456789", input, blafunc);; time;
283
gap> GASMAN("collect"); ListX("0123456789", input, myfuncC);; time;
1494
gap> GASMAN("collect"); ListX("0123456789", input, blafuncC);; time;
1489
gap> GASMAN("collect"); ListX("0123456789", input, myfuncNoConv);; time;
249
gap> GASMAN("collect"); ListX("0123456789", input, blafuncNoConv);; time;
258
```

Some observations:
* The GAP kernel function `ReturnFirst` is sometimes actually slower than the native GAP function `{i,j} -> i`. I suspect that is because `ReturnFirst` is variadic, so its arguments are first packed into a plist and then extracted again.
* With this PR, the function wrappers created by `JuliaFunction` are *faster* than those created by `JuliaBindCFunction`. However, I plan to optimize the latter as well later on, then I hope they'll catch up again.
* The `NoConv` functions are not much (if at all) faster then the ones which perform automatic conversion of arguments. Since immediate integers always have to be converted some way, I also added the test where some of the arguments definitely will not be converted. These then *are* noticably faster, and indeed, on par with the GAP kernel function resp. the native GAP function.

In conclusion, it seems that at least in this micro-benchmark, there seems to be considerable overhead creating a Julia `int64` boxing GAP immediate integers.