### PR TITLE
Avoid crash in Func_JuliaBindCFunction

### DIFF
--- a/JuliaInterface/src/JuliaInterface.c
+++ b/JuliaInterface/src/JuliaInterface.c
@@ -568,7 +568,9 @@ Obj FuncJuliaGetFromMPtr( Obj self, Obj obj )
 Obj Func_JuliaBindCFunction( Obj self, Obj cfunction_string,
                                            Obj number_args_gap, Obj arg_names_gap )
 {
-    void* ccall_pointer = jl_unbox_voidpointer( jl_eval_string( CSTR_STRING( cfunction_string ) ) );
+    jl_value_t* func = jl_eval_string( CSTR_STRING( cfunction_string ) );
+    JULIAINTERFACE_EXCEPTION_HANDLER
+    void* ccall_pointer = jl_unbox_voidpointer( func );
     size_t number_args = INT_INTOBJ( number_args_gap );
     return NewFunction(0, number_args, arg_names_gap, ccall_pointer );
 }


### PR DESCRIPTION
If the input is invalid, then jl_eval_string can fail (trigger
an exception). We need to catch that, otherwise we'll crash