### PR TITLE
JuliaExperimental: load also without Nemo; changed test setup

### DIFF
--- a/JuliaExperimental/gap/gapnemo.g
+++ b/JuliaExperimental/gap/gapnemo.g
@@ -1,0 +1,90 @@
+
+
+
+##############################################################################
+##
+##  Notify the Julia part.
+##
+JuliaIncludeFile(
+    Filename( DirectoriesPackageLibrary( "JuliaExperimental", "julia" ),
+    "gapnemo.jl" ) );
+
+
+#############################################################################
+##
+#F  JuliaArrayOfFmpz( <coeffs> )
+##
+##  For a list <A>coeffs</A> of integers, this function creates
+##  a &Julia; array that contains the corresponding &Julia; objects of type
+##  <C>fmpz</C>.
+##
+BindGlobal( "JuliaArrayOfFmpz", function( coeffs )
+    local arr, i, fmpz, parse, alp, entry, map;
+
+    arr:= [];
+    i:= 1;
+    fmpz:= JuliaFunction( "fmpz", "Nemo" );
+    parse:= JuliaFunction( "parse", "Base" );
+    alp:= ConvertedToJulia( 16 );
+    for entry in coeffs do
+      if IsSmallIntRep( entry ) then
+        arr[i]:= entry;
+      else
+        arr[i]:= parse( fmpz, HexStringInt( entry ), alp );
+      fi;
+      i:= i + 1;
+    od;
+    map:= JuliaFunction( "map", "Base" );
+    arr:= map( fmpz, ConvertedToJulia( arr ) );
+
+    return arr;
+    end );
+
+
+#############################################################################
+##
+#F  JuliaArrayOfFmpq( <coeffs> )
+##
+##  For a list <A>coeffs</A> of rationals, this function creates
+##  a &Julia; array that contains the corresponding &Julia; objects of type
+##  <C>fmpq</C>.
+##
+BindGlobal( "JuliaArrayOfFmpq", function( coeffs )
+    local arr, i, fmpz, fmpq, div, parse, alp, entry, num, den, map;
+
+    arr:= [];
+    i:= 1;
+    fmpz:= JuliaFunction( "fmpz", "Nemo" );
+    fmpq:= JuliaFunction( "fmpq", "Nemo" );
+    div:= Julia.Base.("//");
+    parse:= JuliaFunction( "parse", "Base" );  # why???
+    alp:= ConvertedToJulia( 16 );
+    for entry in coeffs do
+      if IsSmallIntRep( entry ) then
+        arr[i]:= entry;
+      elif IsInt( entry ) then
+        arr[i]:= parse( fmpz, HexStringInt( entry ), alp );
+      else
+        num:= NumeratorRat( entry );
+        den:= DenominatorRat( entry );
+        if not IsSmallIntRep( num ) then
+          num:= parse( fmpz, HexStringInt( num ), alp );
+        fi;
+        if not IsSmallIntRep( den ) then
+          den:= parse( fmpz, HexStringInt( den ), alp );
+        fi;
+        arr[i]:= div( fmpq( num ), fmpq( den ) );
+      fi;
+      i:= i + 1;
+    od;
+    map:= JuliaFunction( "map", "Base" );
+    arr:= map( fmpq, ConvertedToJulia( arr ) );
+
+    return arr;
+    end );
+
+
+#############################################################################
+##
+#E
+

--- a/JuliaExperimental/gap/numfield.g
+++ b/JuliaExperimental/gap/numfield.g
@@ -217,9 +217,9 @@ BindGlobal( "GAPCoefficientsOfNemo_Polynomial", function( pol )
     fi;
 
     if R!.isUnivariatePolynomialRing = true then
-      info:= Julia.GAPUtilsExperimental.CoefficientsOfUnivarateNemoPolynomialFmpq(
+      info:= Julia.GAPNemoExperimental.CoefficientsOfUnivarateNemoPolynomialFmpq(
                  pol );
-      info:= Julia.GAPUtilsExperimental.CoefficientsNumDenOfFmpqArray( info );
+      info:= Julia.GAPNemoExperimental.CoefficientsNumDenOfFmpqArray( info );
       num:= StructuralConvertedFromJulia( info[2] );
       den:= StructuralConvertedFromJulia( info[3] );
       if ConvertedFromJulia( info[1] ) = "int" then
@@ -232,7 +232,7 @@ BindGlobal( "GAPCoefficientsOfNemo_Polynomial", function( pol )
       fi;
     else
       info:= JuliaGetFieldOfObject( pol, "coeffs" );
-      info:= Julia.GAPUtilsExperimental.CoefficientsNumDenOfFmpqArray( info );
+      info:= Julia.GAPNemoExperimental.CoefficientsNumDenOfFmpqArray( info );
       num:= StructuralConvertedFromJulia( info[2] );
       den:= StructuralConvertedFromJulia( info[3] );
       if ConvertedFromJulia( info[1] ) = "int" then

--- a/JuliaExperimental/gap/utils.gi
+++ b/JuliaExperimental/gap/utils.gi
@@ -18,8 +18,6 @@ JuliaIncludeFile(
 
 #############################################################################
 ##
-##
-##
 DeclareAttribute( "JuliaPointer", IsObject );
 
 
@@ -33,118 +31,6 @@ DeclareAttribute( "JuliaPointer", IsObject );
 InstallMethod( ConvertedToJulia,
     [ "HasJuliaPointer" ],
     obj -> JuliaPointer( obj ) );
-
-
-#############################################################################
-##
-##
-##  'result' is bound only if <A>func</A> returned a value.
-##
-##  'Julia_time' measures the wall clock time between the start and the end
-##  of the computations;
-##  this includes both the &GAP; and the &Julia; computations.
-##
-##  'GAP_time' measures the &GAP; runtime of the computations;
-##  this does apparently include most of the time needed by computations
-##  in &Julia;, but for example *not* times spent in <C>sleep</C> calls.
-##
-##  Try to understand better how this works!
-##
-BindGlobal( "CallFuncListWithTimings", function( func, args )
-    local tic, toq, start, result, diff, stop;
-
-    tic:= Julia.Base.tic;
-    toq:= Julia.Base.toq;
-    start:= Runtime();
-    tic();
-    result:= CallFuncListWrap( func, args );
-    stop:= Runtime();
-    diff:= toq();
-
-    if Length( result ) = 1 then
-      return rec( result:= result,
-                  GAP_time:= stop - start,
-                  Julia_time:= Int( 1000 * ConvertedFromJulia( diff ) ) );
-    else
-      return rec( result:= result,
-                  GAP_time:= stop - start,
-                  Julia_time:= Int( 1000 * ConvertedFromJulia( diff ) ) );
-    fi;
-    end );
-
-
-#############################################################################
-##
-#F  JuliaArrayOfFmpz( <coeffs> )
-##
-##  For a list <A>coeffs</A> of integers, this function creates
-##  a &Julia; array that contains the corresponding &Julia; objects of type
-##  <C>fmpz</C>.
-##
-BindGlobal( "JuliaArrayOfFmpz", function( coeffs )
-    local arr, i, fmpz, parse, alp, entry, map;
-
-    arr:= [];
-    i:= 1;
-    fmpz:= JuliaFunction( "fmpz", "Nemo" );
-    parse:= JuliaFunction( "parse", "Base" );
-    alp:= ConvertedToJulia( 16 );
-    for entry in coeffs do
-      if IsSmallIntRep( entry ) then
-        arr[i]:= entry;
-      else
-        arr[i]:= parse( fmpz, HexStringInt( entry ), alp );
-      fi;
-      i:= i + 1;
-    od;
-    map:= JuliaFunction( "map", "Base" );
-    arr:= map( fmpz, ConvertedToJulia( arr ) );
-
-    return arr;
-    end );
-
-
-#############################################################################
-##
-#F  JuliaArrayOfFmpq( <coeffs> )
-##
-##  For a list <A>coeffs</A> of rationals, this function creates
-##  a &Julia; array that contains the corresponding &Julia; objects of type
-##  <C>fmpq</C>.
-##
-BindGlobal( "JuliaArrayOfFmpq", function( coeffs )
-    local arr, i, fmpz, fmpq, div, parse, alp, entry, num, den, map;
-
-    arr:= [];
-    i:= 1;
-    fmpz:= JuliaFunction( "fmpz", "Nemo" );
-    fmpq:= JuliaFunction( "fmpq", "Nemo" );
-    div:= Julia.Base.("//");
-    parse:= JuliaFunction( "parse", "Base" );  # why???
-    alp:= ConvertedToJulia( 16 );
-    for entry in coeffs do
-      if IsSmallIntRep( entry ) then
-        arr[i]:= entry;
-      elif IsInt( entry ) then
-        arr[i]:= parse( fmpz, HexStringInt( entry ), alp );
-      else
-        num:= NumeratorRat( entry );
-        den:= DenominatorRat( entry );
-        if not IsSmallIntRep( num ) then
-          num:= parse( fmpz, HexStringInt( num ), alp );
-        fi;
-        if not IsSmallIntRep( den ) then
-          den:= parse( fmpz, HexStringInt( den ), alp );
-        fi;
-        arr[i]:= div( fmpq( num ), fmpq( den ) );
-      fi;
-      i:= i + 1;
-    od;
-    map:= JuliaFunction( "map", "Base" );
-    arr:= map( fmpq, ConvertedToJulia( arr ) );
-
-    return arr;
-    end );
 
 
 ##############################################################################

--- a/JuliaExperimental/julia/gapnemo.jl
+++ b/JuliaExperimental/julia/gapnemo.jl
@@ -1,0 +1,59 @@
+##############################################################################
+##
+##  gapnemo.jl
+##
+##  some utility functions for creating Nemo objects
+##
+
+module GAPNemoExperimental
+
+import Nemo
+
+"""
+    fitsGAPSmallIntRep( x::Nemo.fmpz )
+> Return `true` if `x` corresponds to a GAP integer in `IsSmallIntRep`,
+> and `false` otherwise.
+"""
+function fitsGAPSmallIntRep( x::Nemo.fmpz )
+    return -2^60 <= x && x < 2^60
+end
+
+
+function CoefficientsOfUnivarateNemoPolynomialFmpq( pol::Nemo.fmpq_poly )
+    return map( i -> Nemo.coeff( pol, i ), 0:(length(pol)-1) )
+end
+
+
+"""
+    CoefficientsNumDenOfFmpqArray( arr::Array{Nemo.fmpq,1}[, tryint::Bool = true] )
+> Return a tuple `(<kind>, <arrnum>, <arrden>)` where <arrnum>, <arrden>
+> are 1-dim. arrays of the numerators and denominators of the values in <arr>,
+> and <kind> is either `"int"` (the entries are small integers)
+> or `"string"` (the entries are hex strings).
+> This format is suitable for calling `ConvertedFromJulia` from GAP.
+"""
+function CoefficientsNumDenOfFmpqArray( arr::Array{Nemo.fmpq,1}, tryint::Bool = true )
+    n = length( arr )
+    coeffsnum = map( i -> numerator( arr[i] ), 1:n )
+    coeffsden = map( i -> denominator( arr[i] ), 1:n )
+
+    if tryint == true
+      # Check whether the entries are small enough for being unboxed
+      # to small integers in GAP, i. e., in the range '[ -2^60 .. 2^60-1 ]'.
+      fits = [ fitsGAPSmallIntRep( coeffsnum[i] ) for i in 1:n ]
+      if all( [ fitsGAPSmallIntRep( coeffsnum[i] ) for i in 1:n ] ) &&
+         all( [ fitsGAPSmallIntRep( coeffsden[i] ) for i in 1:n ] )
+        return ( "int", map( Int, coeffsnum ), map( Int, coeffsden ) )
+      end
+    end
+
+    # Either we *want* to create a nested array of strings,
+    # or some entry is too large.
+    # Turn the 2-dim. array into a 1-dim. array of 1-dim. arrays
+    # (which can then be unboxed with 'ConvertedFromJulia').
+    return ( "string", [ hex( coeffsnum[i] ) for i in 1:n ],
+                       [ hex( coeffsden[i] ) for i in 1:n ] )
+end
+
+end
+

--- a/JuliaExperimental/julia/gaprat.jl
+++ b/JuliaExperimental/julia/gaprat.jl
@@ -75,10 +75,10 @@ function isless( a::GAPRat, b::GAPRat )
 end
 
 function +( a::GAPRat, b::GAPRat )
-  # ptr = ccall( Main.gap_MyFuncSUM, Ptr{Cvoid},
-  #             (Ptr{Cvoid}, Ptr{Cvoid}), a.obj.ptr, b.obj.ptr )
-  # return GAPRat( GapObj(ptr) )
-    return GAPRat( SUM( a.obj, b.obj ) )
+    ptr = ccall( Main.gap_MyFuncSUM, Ptr{Cvoid},
+                (Ptr{Cvoid}, Ptr{Cvoid}), a.obj.ptr, b.obj.ptr )
+    return GAPRat( GapObj(ptr) )
+#   return GAPRat( SUM( a.obj, b.obj ) )
 end
 
 function -( a::GAPRat, b::GAPRat )

--- a/JuliaExperimental/julia/realcyc.jl
+++ b/JuliaExperimental/julia/realcyc.jl
@@ -55,7 +55,7 @@ function test_this_module()
     ok::Bool = true
 
     function shiftby( array, int )
-      sum = array + int
+      sum = map( x -> x + int, array )
       sum[1] = 0
       return sum
     end

--- a/JuliaExperimental/julia/utils.jl
+++ b/JuliaExperimental/julia/utils.jl
@@ -7,10 +7,7 @@
 
 module GAPUtilsExperimental
 
-import Nemo
-
-export MatrixFromNestedArray, CoefficientsNumDenOfNemoPolynomialFmpq,
-       JuliaSourceFile
+# export MatrixFromNestedArray, JuliaSourceFile
 
 """
     MatrixFromNestedArray( lst )
@@ -21,55 +18,14 @@ function MatrixFromNestedArray( lst ) return hcat( lst... )' end
 
 
 """
-    fitsGAPSmallIntRep( x::Nemo.fmpz )
-> Return `true` if `x` corresponds to a GAP integer in `IsSmallIntRep`,
-> and `false`otherwise.
+    NestedArrayFromMatrix( lst )
+> Return an array of 1-dim arrays created from the 2-dim array `lst`.
+> (Note that GAP's `ConvertedFromJulia` expects nested arrays.)
 """
-function fitsGAPSmallIntRep( x::Nemo.fmpz )
-    return -2^60 <= x && x < 2^60
-end
-
-
-function CoefficientsOfUnivarateNemoPolynomialFmpq( pol::Nemo.fmpq_poly )
-    return map( i -> Nemo.coeff( pol, i ), 0:(length(pol)-1) )
-end
-
-
 function NestedArrayFromMatrix( mat )
     return map( i -> mat[i,:], 1:size(mat,1) )
 end
 
-
-"""
-    CoefficientsNumDenOfFmpqArray( arr::Array{Nemo.fmpq,1}[, tryint::Bool = true] )
-> Return a tuple `(<kind>, <arrnum>, <arrden>)` where <arrnum>, <arrden>
-> are 1-dim. arrays of the numerators and denominators of the values in <arr>,
-> and <kind> is either `"int"` (the entries are small integers)
-> or `"string"` (the entries are hex strings).
-> This format is suitable for calling `ConvertedFromJulia` from GAP.
-"""
-function CoefficientsNumDenOfFmpqArray( arr::Array{Nemo.fmpq,1}, tryint::Bool = true )
-    n = length( arr )
-    coeffsnum = map( i -> numerator( arr[i] ), 1:n )
-    coeffsden = map( i -> denominator( arr[i] ), 1:n )
-
-    if tryint == true
-      # Check whether the entries are small enough for being unboxed
-      # to small integers in GAP, i. e., in the range '[ -2^60 .. 2^60-1 ]'.
-      fits = [ fitsGAPSmallIntRep( coeffsnum[i] ) for i in 1:n ]
-      if all( [ fitsGAPSmallIntRep( coeffsnum[i] ) for i in 1:n ] ) &&
-         all( [ fitsGAPSmallIntRep( coeffsden[i] ) for i in 1:n ] )
-        return ( "int", map( Int, coeffsnum ), map( Int, coeffsden ) )
-      end
-    end
-
-    # Either we *want* to create a nested array of strings,
-    # or some entry is too large.
-    # Turn the 2-dim. array into a 1-dim. array of 1-dim. arrays
-    # (which can then be unboxed with 'ConvertedFromJulia').
-    return ( "string", [ hex( coeffsnum[i] ) for i in 1:n ],
-                       [ hex( coeffsden[i] ) for i in 1:n ] )
-end
 
 """
     JuliaSourceFile( func, types )

--- a/JuliaExperimental/read.g
+++ b/JuliaExperimental/read.g
@@ -14,7 +14,6 @@ ReadPackage( "JuliaExperimental", "gap/arith.gi");
 # BindJuliaFunc( "juliabox_cycs" );
 # 
 
-
 # Translate GAP records to Julia dictionaries and vice versa.
 ReadPackage( "JuliaExperimental", "gap/record.g");
 
@@ -39,6 +38,7 @@ ReadPackage( "JuliaExperimental", "gap/gapperm.g");
 
 # Nemo's number fields.
 if JuliaImportPackage( "Nemo" ) then
+  ReadPackage( "JuliaExperimental", "gap/gapnemo.g");
   ReadPackage( "JuliaExperimental", "gap/numfield.g");
 fi;
 

--- a/JuliaExperimental/tst/gapnemo.tst
+++ b/JuliaExperimental/tst/gapnemo.tst
@@ -1,0 +1,21 @@
+#############################################################################
+##
+#W  gapnemo.tst        GAP 4 package JuliaExperimental          Thomas Breuer
+##
+gap> START_TEST( "gapnemo.tst" );
+
+##  small or large integers
+gap> l:= JuliaArrayOfFmpz( [ -2, -1, 0, 1, 2, 3 ] );
+<Julia: Nemo.fmpz[-2, -1, 0, 1, 2, 3]>
+gap> l:= JuliaArrayOfFmpz( [ 1, 2, 3, 2^70 ] );
+<Julia: Nemo.fmpz[1, 2, 3, 1180591620717411303424]>
+
+##  small or large rationals
+gap> l:= JuliaArrayOfFmpq( [ -2, -1/2, 0, 1, 2/3, 3/7 ] );
+<Julia: Nemo.fmpq[-2, -1//2, 0, 1, 2//3, 3//7]>
+gap> l:= JuliaArrayOfFmpq( [ 2^70/3, 1/2^70 ] );
+<Julia: Nemo.fmpq[1180591620717411303424//3, 1//1180591620717411303424]>
+
+##
+gap> STOP_TEST( "gapnemo.tst", 1 );
+

--- a/JuliaExperimental/tst/hnf.tst
+++ b/JuliaExperimental/tst/hnf.tst
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W  hnf.tst         GAP 4 package JuliaExperimental          Thomas Breuer
+#W  hnf.tst            GAP 4 package JuliaExperimental          Thomas Breuer
 ##
 gap> START_TEST( "hnf.tst" );
 

--- a/JuliaExperimental/tst/record.tst
+++ b/JuliaExperimental/tst/record.tst
@@ -15,9 +15,9 @@ rec(  )
 gap> StructuralConvertedFromJulia_AlsoRecord( dict );
 rec(  )
 
-##  something which cannot be boxed
-gap> ConvertedToJulia( rec( GAPfunc:= ( x -> 1 ) ) );
-fail
+# ##  something which cannot be boxed
+# gap> ConvertedToJulia( rec( GAPfunc:= ( x -> 1 ) ) );
+# fail
 
 ##  something which is recursive
 gap> dict:= ConvertedToJulia( rec( bool:= true,
@@ -27,7 +27,7 @@ gap> dict:= ConvertedToJulia( rec( bool:= true,
 >                        ) );;
 gap> ConvertedFromJuliaRecordFromDictionary( dict );
 rec( Juliafunc := <Julia: map>, bool := <Julia: true>, 
-  list := <Julia: Any[1, 2, 3]>, string := <Julia: abc> )
+  list := <Julia: Any[1, 2, 3]>, string := <Julia: "abc"> )
 gap> StructuralConvertedFromJulia_AlsoRecord( dict );
 rec( Juliafunc := fail, bool := true, list := [ 1, 2, 3 ], string := "abc" )
 

--- a/JuliaExperimental/tst/testall.g
+++ b/JuliaExperimental/tst/testall.g
@@ -1,14 +1,34 @@
 #
 # JuliaExperimental: Experimental code for the GAP Julia integration
 #
-# This file runs package tests. It is also referenced in the package
-# metadata in PackageInfo.g.
+# This file runs package tests.
+# It is referenced in the package metadata in PackageInfo.g.
 #
 LoadPackage( "JuliaExperimental" );
 
-dirs := DirectoriesPackageLibrary( "JuliaExperimental", "tst" );
+pairs:= [
+  [ "gapnemo.tst", [ "Nemo" ] ],
+  [ "gaprat.tst", [] ],
+  [ "hnf.tst", [ "Nemo" ] ],
+# [ "numfield.tst", [ "Nemo" ] ],
+  [ "realcyc.tst", [ "Nemo" ] ],
+  [ "record.tst", [] ],
+  [ "utils.tst", [] ],
+];
+
+dirs:= DirectoriesPackageLibrary( "JuliaExperimental", "tst" );
 Assert(0, dirs <> fail);
 
-TestDirectory(dirs, rec(exitGAP := true));
+# Run only those tests that are supported by the current Julia installation.
+pairs:= Filtered( pairs, x -> ForAll( x[2], JuliaImportPackage ) );
+files:= List( pairs, x -> Filename( dirs, x[1] ) );
+if fail in files then
+  Print( "#E  unavailable test files:\n",
+         List( pairs{ Positions( files, fail ) }, x -> x[1] ), "\n" );
+  files:= Filtered( files, IsString );
+fi;
+
+TestDirectory( files, rec(exitGAP := true));
 
 FORCE_QUIT_GAP(1);
+

--- a/JuliaExperimental/tst/utils.tst
+++ b/JuliaExperimental/tst/utils.tst
@@ -1,24 +1,12 @@
 #############################################################################
 ##
-#W  utils.tst         GAP 4 package JuliaExperimental          Thomas Breuer
+#W  utils.tst         GAP 4 package JuliaExperimental           Thomas Breuer
 ##
 gap> START_TEST( "utils.tst" );
 
-##  small or large integers
-gap> l:= JuliaArrayOfFmpz( [ -2, -1, 0, 1, 2, 3 ] );
-<Julia: Nemo.fmpz[-2, -1, 0, 1, 2, 3]>
-gap> l:= JuliaArrayOfFmpz( [ 1, 2, 3, 2^70 ] );
-<Julia: Nemo.fmpz[1, 2, 3, 1180591620717411303424]>
-
-##  small or large rationals
-gap> l:= JuliaArrayOfFmpq( [ -2, -1/2, 0, 1, 2/3, 3/7 ] );
-<Julia: Nemo.fmpq[-2, -1//2, 0, 1, 2//3, 3//7]>
-gap> l:= JuliaArrayOfFmpq( [ 2^70/3, 1/2^70 ] );
-<Julia: Nemo.fmpq[1180591620717411303424//3, 1//1180591620717411303424]>
-
 ##
-gap> RecNames( CallFuncListWithTimings( Julia.Base.sleep, [ 2 ] ) );
-[ "result", "GAP_time", "Julia_time" ]
+gap> JuliaMatrixFromGapMatrix( [ [ 1, 2 ], [ 3, 4 ] ] );
+<Julia: [1 2; 3 4]>
 
 ##
 gap> STOP_TEST( "utils.tst", 1 );


### PR DESCRIPTION
We do not want to require any particular Julia package
when we load JuliaExperimental.
(Of course most code of the package will not be available
if no Julia packages are available.)
For that, `gap/utils.gi` and `julia/utils.jl` have been split
into a Nemo independent part and a part which requires Nemo.
(This addresses issue #65.)

The same holds for the test files,
we cannot expect that all tests can be run with a given installation
of Julia.
Therefore, `TestDirectory` has to be run just on those test files
for which the necessary Julia packages are available.

Besides the general test mechanism,
also some tests have now been adjusted to Julia 1.0.