### PR TITLE
JuliaInterface: remove more dead code

### DIFF
--- a/JuliaInterface/src/JuliaInterface.c
+++ b/JuliaInterface/src/JuliaInterface.c
@@ -811,6 +811,19 @@ static Obj FuncJuliaModule(Obj self, Obj name)
     return NewJuliaObj((jl_value_t *)julia_module);
 }
 
+// Sets the value of the julia identifier <name> to the julia value the julia
+// object GAP object <julia_val> points to.
+// This function is for debugging purposes
+static Obj FuncJuliaSetVal(Obj self, Obj name, Obj julia_val)
+{
+    jl_value_t * julia_obj = GET_JULIA_OBJ(julia_val);
+    jl_sym_t *   julia_symbol = jl_symbol(CSTR_STRING(name));
+    JULIAINTERFACE_EXCEPTION_HANDLER
+    jl_set_global(jl_main_module, julia_symbol, julia_obj);
+    JULIAINTERFACE_EXCEPTION_HANDLER
+    return 0;
+}
+
 // Returns the julia object GAP object that holds a pointer to the value
 // currently bound to the julia identifier <name>.
 static Obj Func_JuliaGetGlobalVariable(Obj self, Obj name)
@@ -897,6 +910,7 @@ static StructGVarFunc GVarFuncs[] = {
     GVAR_FUNC(JuliaEvalString, 1, "string"),
     GVAR_FUNC(_ConvertedFromJulia, 1, "obj"),
     GVAR_FUNC(_ConvertedToJulia, 1, "obj"),
+    GVAR_FUNC(JuliaSetVal, 2, "name,val"),
     GVAR_FUNC(_JuliaGetGlobalVariable, 1, "name"),
     GVAR_FUNC(_JuliaGetGlobalVariableByModule, 2, "name,module"),
     GVAR_FUNC(JuliaGetFieldOfObject, 2, "obj,name"),

--- a/JuliaInterface/tst/utils.tst
+++ b/JuliaInterface/tst/utils.tst
@@ -23,6 +23,11 @@ rec( ok := false,
   value := "DomainError(-1.0, \"sqrt will only return a complex result if call\
 ed with a complex argument. Try sqrt(Complex(x)).\")" )
 
+#
+gap> JuliaSetVal("foo", JuliaEvalString("1"));
+gap> JuliaGetGlobalVariable("foo");
+<Julia: 1>
+
 ##
 gap> STOP_TEST( "utils.tst", 1 );
 


### PR DESCRIPTION
All of the removed functions are potentially useful. However, I believe that
we will be better off reimplementing them in Julia, and then exporting these
Julia functions to GAP.

But maybe my believe is wrong... perhaps if one needs to use these functions in tight loop, having them as pure C is beneficial... but then again, I don't think using them in a tight loop is a good idea either way. I mean, setting a global Julia variable is not something a lot of code should do, if any; certainly not in a tight loop. Likewise, converting from/to GapObj wrappers strikes me as something you want to avoid in efficient code anyway, and would ideally do only once at the start and once at the end.