### PR TITLE
Travis: don't process whole GAPJulia dir with Coverage.jl

### DIFF
--- a/etc/gather_coverage.jl
+++ b/etc/gather_coverage.jl
@@ -6,7 +6,9 @@ using Coverage
 import JSON
 
 # gather coverage
-data = Codecov.process_folder(pwd())
+data = Codecov.process_folder("JuliaInterface")
+append!(data, Codecov.process_folder("JuliaExperimental"))
+append!(data, Codecov.process_folder("LibGAP.jl"))
 data_dict = Codecov.to_json(data)
 
 # write it to a file for the upload script


### PR DESCRIPTION
... because on Travis, we also put a gap subdir into it, leading
to Coverage.jl scanning all of that, which clogs up the Travis log.