### PR TITLE
Use julia_gap and gap_julia in more places

### DIFF
--- a/JuliaExperimental/tst/realcyc.tst
+++ b/JuliaExperimental/tst/realcyc.tst
@@ -37,7 +37,7 @@ false
 
 ##
 gap> Julia.GAPRealCycModule.test_this_module();
-<Julia: true>
+true
 
 ##
 gap> STOP_TEST( "realcyc.tst", 1 );

--- a/JuliaInterface/gap/JuliaInterface.gd
+++ b/JuliaInterface/gap/JuliaInterface.gd
@@ -44,7 +44,7 @@ DeclareOperation( "ConvertedToJulia", [ IsObject ] );
 #! @Description
 #!  Retuns an object that is a sensible conversion from the Julia object <A>julia_object</A>.
 #!  If no conversion exists, <C>fail</C> is returned.
-DeclareOperation( "ConvertedFromJulia", [ IsJuliaObject ] );
+DeclareOperation( "ConvertedFromJulia", [ IsObject ] );
 
 #! @Arguments julia_object
 #! @Returns an object
@@ -139,5 +139,3 @@ DeclareGlobalFunction( "JuliaTypeInfo" );
 #!  If an error occured then <C>ok</C> has the value <K>false</K>,
 #!  and <C>value</C> is the error message as a &GAP; string.
 DeclareGlobalFunction( "CallJuliaFunctionWithCatch" );
-
-

--- a/JuliaInterface/gap/JuliaInterface.gi
+++ b/JuliaInterface/gap/JuliaInterface.gi
@@ -28,6 +28,10 @@ InstallMethod( ConvertedFromJulia,
                [ IsJuliaObject ],
     _ConvertedFromJulia );
 
+InstallMethod( ConvertedFromJulia,
+               [ IsObject ],
+    IdFunc );
+
 InstallMethod( ConvertedToJulia,
                 [ IsObject ],
   function( obj )
@@ -91,9 +95,9 @@ InstallMethod( \.,
         Error( rnam, " is not bound in Julia" );
     fi;
 
-    if ConvertedFromJulia( _JULIA_ISA( global_variable, _JULIA_FUNCTION_TYPE ) ) then
+    if _JULIA_ISA( global_variable, _JULIA_FUNCTION_TYPE ) then
         global_variable := _JuliaFunction( global_variable, true );
-    elif ConvertedFromJulia( _JULIA_ISA( global_variable, _JULIA_MODULE_TYPE ) ) then
+    elif _JULIA_ISA( global_variable, _JULIA_MODULE_TYPE ) then
         global_variable := _WrapJuliaModule( rnam, global_variable );
     fi;
 
@@ -195,7 +199,7 @@ InstallGlobalFunction( ImportJuliaModuleIntoGAP,
     is_module_present := JuliaEvalString( Concatenation( "isdefined( Main, :", name, ")" ) );
     
     if no_import = false then
-        if not ConvertedFromJulia( is_module_present ) then
+        if not is_module_present then
             ## Local modules cannot be imported
             callstring:= Concatenation( "import ", name );
             JuliaEvalString( callstring );
@@ -218,7 +222,7 @@ InstallGlobalFunction( JuliaImportPackage, function( pkgname )
     fi;
     callstring := Concatenation( "try import ", pkgname,
                      "; return true; catch e; return e; end" );
-    if ConvertedFromJulia( JuliaEvalString( callstring ) ) = true then
+    if JuliaEvalString( callstring ) = true then
         return true;
     else
       Info( InfoWarning, 1,
@@ -238,7 +242,7 @@ InstallGlobalFunction( CallJuliaFunctionWithCatch,
     local res;
 
     res:= Julia.GAPUtils.call_with_catch( juliafunc, arguments );
-    if ConvertedFromJulia( res[1] ) = true then
+    if res[1] then
       return rec( ok:= true, value:= res[2] );
     else
       return rec( ok:= false, value:= ConvertedFromJulia( res[2] ) );

--- a/JuliaInterface/src/calls.c
+++ b/JuliaInterface/src/calls.c
@@ -101,10 +101,7 @@ static ALWAYS_INLINE Obj DoCallJuliaFunc(Obj       func,
     }
     else {
         for (int i = 0; i < narg; i++) {
-            if (IS_INTOBJ(a[i]))
-                a[i] = (Obj)jl_box_int64(INT_INTOBJ(a[i]));
-            else if (IS_FFE(a[i]))
-                ErrorQuit("TODO: implement conversion for T_FFE", 0, 0);
+            a[i] = (Obj)julia_gap(a[i]);
         }
     }
     jl_function_t * f = GET_JULIA_FUNC(func);
@@ -129,9 +126,7 @@ static ALWAYS_INLINE Obj DoCallJuliaFunc(Obj       func,
     // and its variants are part of the jlapi, so don't have to be wrapped in
     // JL_TRY/JL_CATCH.
     JULIAINTERFACE_EXCEPTION_HANDLER
-    if (IsGapObj(result))
-        return (Obj)result;
-    return NewJuliaObj(result);
+    return gap_julia(result);
 }
 
 static Obj DoCallJuliaFunc0ArgConv(Obj func)

--- a/JuliaInterface/tst/calls.tst
+++ b/JuliaInterface/tst/calls.tst
@@ -176,31 +176,31 @@ gap> fwN();
 
 #
 gap> fwN(true);
-<Julia: (GAP: true,)>
+<Julia: (true,)>
 
 #
 gap> fwN(true,2);
-<Julia: (GAP: true, 2)>
+<Julia: (true, 2)>
 
 #
 gap> fwN(true,2,3);
-<Julia: (GAP: true, 2, 3)>
+<Julia: (true, 2, 3)>
 
 #
 gap> fwN(true,2,3,4);
-<Julia: (GAP: true, 2, 3, 4)>
+<Julia: (true, 2, 3, 4)>
 
 #
 gap> fwN(true,2,3,4,5);
-<Julia: (GAP: true, 2, 3, 4, 5)>
+<Julia: (true, 2, 3, 4, 5)>
 
 #
 gap> fwN(true,2,3,4,5,6);
-<Julia: (GAP: true, 2, 3, 4, 5, 6)>
+<Julia: (true, 2, 3, 4, 5, 6)>
 
 #
 gap> fwN(true,2,3,4,5,6,7);
-<Julia: (GAP: true, 2, 3, 4, 5, 6, 7)>
+<Julia: (true, 2, 3, 4, 5, 6, 7)>
 
 # non-variadic functions
 gap> f0wN := _JuliaFunction("f0", false);;
@@ -218,31 +218,31 @@ gap> f0wN();
 
 #
 gap> f1wN(true);
-<Julia: (GAP: true,)>
+<Julia: (true,)>
 
 #
 gap> f2wN(true,2);
-<Julia: (GAP: true, 2)>
+<Julia: (true, 2)>
 
 #
 gap> f3wN(true,2,3);
-<Julia: (GAP: true, 2, 3)>
+<Julia: (true, 2, 3)>
 
 #
 gap> f4wN(true,2,3,4);
-<Julia: (GAP: true, 2, 3, 4)>
+<Julia: (true, 2, 3, 4)>
 
 #
 gap> f5wN(true,2,3,4,5);
-<Julia: (GAP: true, 2, 3, 4, 5)>
+<Julia: (true, 2, 3, 4, 5)>
 
 #
 gap> f6wN(true,2,3,4,5,6);
-<Julia: (GAP: true, 2, 3, 4, 5, 6)>
+<Julia: (true, 2, 3, 4, 5, 6)>
 
 #
 gap> f7wN(true,2,3,4,5,6,7);
-<Julia: (GAP: true, 2, 3, 4, 5, 6, 7)>
+<Julia: (true, 2, 3, 4, 5, 6, 7)>
 
 #
 # calls via wrapped C function pointers
@@ -280,17 +280,17 @@ Error, Only 0-6 arguments are supported
 gap> g0();
 <Julia: Ptr{Nothing} @0x0000000000000000>
 gap> g1(true);
-<Julia: true>
+true
 gap> g2(true,2);
-<Julia: 2>
+2
 gap> g3(true,2,3);
-<Julia: 3>
+3
 gap> g4(true,2,3,4);
-<Julia: 4>
+4
 gap> g5(true,2,3,4,5);
-<Julia: 5>
+5
 gap> g6(true,2,3,4,5,6);
-<Julia: 6>
+6
 
 #
 gap> g0C();
@@ -344,7 +344,7 @@ Error, TypeError: in h6, in cfunction, expected Ptr{Nothing}, got Nothing
 #
 gap> _NewJuliaCFunc(fail, fail);
 Error, NewJuliaCFunc: <ptr> must be a Julia object
-gap> _NewJuliaCFunc(JuliaEvalString("1"), fail);
+gap> _NewJuliaCFunc(JuliaEvalString("'a'"), fail);
 Error, NewJuliaCFunc: <arg_names> must be plain list
 
 #

--- a/JuliaInterface/tst/utils.tst
+++ b/JuliaInterface/tst/utils.tst
@@ -32,7 +32,7 @@ gap> JuliaSetVal(fail, 1);
 Error, JuliaSetVal: <name> must be a string
 gap> JuliaSetVal("foo", JuliaEvalString("1"));
 gap> JuliaGetGlobalVariable("foo");
-<Julia: 1>
+1
 
 ##
 gap> JuliaTuple([]);


### PR DESCRIPTION
... for consistency in the auto-conversion behaviour of JuliaInterface versus
LibGAP.jl, and for ease of use.

There is more work to be done here, though, and we need to properly
document the rules for when and where which conversion is applied,
and why.