### PR TITLE
Remove some obsolete exports, move GapObj

### DIFF
--- a/JuliaExperimental/julia/gaprat.jl
+++ b/JuliaExperimental/julia/gaprat.jl
@@ -10,9 +10,17 @@ module GAPRatModule
 import Base: zero, -, one, inv, ==, isless, +, *, //, ^, mod, iszero, string,
              numerator, denominator, abs, gcd
 
-import Main.GAP: GapObj
-
 export GAPRat, get_gaprat_ptr
+
+"""
+    GapObj
+
+> Holds a pointer to an object in the GAP CAS, and additionally some internal information for
+> GAP's garbage collection. It can be used as arguments for GapFunc's.
+"""
+mutable struct GapObj
+    ptr::Ptr{Cvoid}
+end
 
 struct GAPRat
     obj::GapObj

--- a/JuliaInterface/gap/BindCFunction.gd
+++ b/JuliaInterface/gap/BindCFunction.gd
@@ -18,7 +18,7 @@
 #!  Returns a GAP function that acts like a kernel function in GAP,
 #!  but calls the Julia function <A>julia_name</A>. The function in Julia
 #!  must exist, bound to the global name <A>julia_name</A> in the module <C>Main</C>,
-#!  and must be callable on <A>nr_args</A> <C>GAP.GapObj</C>. <A>arg_name</A> must
+#!  and must be callable on <A>nr_args</A> arguments. <A>arg_name</A> must
 #!  be a list of strings of length <A>nr_args</A> describing the argument names
 #!  that are displayed in the function header by &GAP;.
 DeclareGlobalFunction( "JuliaBindCFunction" );
@@ -29,5 +29,5 @@ DeclareGlobalFunction( "JuliaBindCFunction" );
 #! @Returns nothing
 #! @Description
 #!  Sets the function <A>func</A> in Julia as <C>GAP.</C><A>name</A>.
-#!  The resulting function is then callable from Julia on <A>argument_number</A> <C>GAP.GapObj</C>s.
+#!  The resulting function is then callable from Julia on <A>argument_number</A> arguments.
 DeclareGlobalFunction( "JuliaSetGAPFuncAsJuliaObjFunc" );

--- a/JuliaInterface/julia/gaptypes.jl
+++ b/JuliaInterface/julia/gaptypes.jl
@@ -57,20 +57,8 @@ import Base: getproperty
 
 import Main.ForeignGAP: MPtr
 
-export gap_funcs, prepare_func_for_gap, GapObj, GapFunc, gap_object_finalizer
+export GapFunc
 
-gap_funcs = []
-
-
-"""
-    GapObj
-
-> Holds a pointer to an object in the GAP CAS, and additionally some internal information for
-> GAP's garbage collection. It can be used as arguments for GapFunc's.
-"""
-mutable struct GapObj
-    ptr::Ptr{Cvoid}
-end
 
 """
     GapFunc


### PR DESCRIPTION
... to JuliaExperimental/julia/gaprat.jl, where it hopefully can eventually be removed completely.

I did leave a few references to `GapObj` in comments for `GapFuncs`, as I think those will have to be completely rewritten soon anyway (see issue #123), so there is no point in changing them now (to the contrary, this could cause conflicts with work @sebasguts might be doing)