### PR TITLE
Convert Julia bigints to GAP large ints

### DIFF
--- a/JuliaInterface/tst/convert.tst
+++ b/JuliaInterface/tst/convert.tst
@@ -98,6 +98,18 @@ gap> ConvertedFromJulia(x);
 ###
 
 #
+gap> big2 := JuliaEvalString("big(2)");
+<Julia: 2>
+gap> Zero(big2);
+<Julia: 0>
+gap> ConvertedFromJulia( Zero(big2) );
+0
+gap> ForAll([0..64], n -> ConvertedFromJulia(big2^n) = 2^n);
+true
+gap> ForAll([0..64], n -> ConvertedFromJulia(-big2^n) = -2^n);
+true
+
+#
 gap> string := ConvertedToJulia( "bla" );
 <Julia: "bla">
 gap> ConvertedFromJulia( string );


### PR DESCRIPTION
The other conversion direction is missing because it is a bit fickly to correctly create Julia bigints from C; in particular, this code does it, taken from Julia's `src/dump.c`, but it uses `jl_gc_counted_malloc` which is not exported from the public Julia headers:
```C
    else if ((jl_value_t*)dt == jl_bigint_type) {
        jl_value_t *sizefield = jl_deserialize_value(s, NULL);
        int32_t sz = jl_unbox_int32(sizefield);
        int32_t nw = (sz == 0 ? 1 : (sz < 0 ? -sz : sz));
        size_t nb = nw * gmp_limb_size;
        void *buf = jl_gc_counted_malloc(nb);
        ios_read(s->s, (char*)buf, nb);
        jl_set_nth_field(v, 0, jl_box_int32(nw));
        jl_set_nth_field(v, 1, sizefield);
        jl_set_nth_field(v, 2, jl_box_voidpointer(buf));
    }
```
All in all, I think it might be better to write the GAP->Julia conversion in Julia, not in C, i.e., add another `BigInt` constructor which takes a GAP large int, and does the right thing. In any case, I won't solve this tonight.