### PR TITLE
Add QUO and LQUO methods for IsJuliaObject, improve tests

### DIFF
--- a/JuliaInterface/gap/arith.gi
+++ b/JuliaInterface/gap/arith.gi
@@ -42,6 +42,8 @@ Perform([[ "IsJuliaObject", "IsJuliaObject" ],
         InstallOtherMethod( \+, argTypes, Julia.Base.\+ );
         InstallOtherMethod( \*, argTypes, Julia.Base.\* );
         InstallOtherMethod( \-, argTypes, Julia.Base.\- );
+        InstallOtherMethod( \/, argTypes, Julia.Base.\/ );
+        InstallOtherMethod( LQUO, argTypes, Julia.Base.\\ );
         InstallOtherMethod( \^, argTypes, Julia.Base.\^ );
         InstallOtherMethod( \=, argTypes, Julia.Base.\=\= );
         InstallOtherMethod( \<, argTypes, Julia.Base.\< );

--- a/JuliaInterface/tst/arith.tst
+++ b/JuliaInterface/tst/arith.tst
@@ -56,16 +56,16 @@ gap> N^2 = N_squared;
 true
 
 #
-#gap> N / N = 1;
-#true
-#gap> N / 2^50 = 2^50;
-#true
+gap> N / N;
+<Julia: 1.0>
+gap> N / 2^50;
+<Julia: 1.125899906842624e+15>
 
 #
-#gap> N \ N = 1;
-#true
-#gap> 2^50 \ N = 2^50;
-#true
+gap> LQUO(N, N);
+<Julia: 1.0>
+gap> LQUO(2^50, N);
+<Julia: 1.125899906842624e+15>
 
 #
 gap> data := [ -N_p1, -N, -N_m1, -1, 0, 1, N_m1, N, N_p1 ];;

--- a/JuliaInterface/tst/arith.tst
+++ b/JuliaInterface/tst/arith.tst
@@ -2,80 +2,89 @@
 gap> START_TEST( "arith.tst" );
 
 #
-gap> large_int := JuliaEvalString("big(2)^100");
+gap> N := JuliaEvalString("big(2)^100");
 <Julia: 1267650600228229401496703205376>
-gap> large_int_p1 := JuliaEvalString("big(2)^100 + 1");
+gap> N_p1 := JuliaEvalString("big(2)^100 + 1");
 <Julia: 1267650600228229401496703205377>
-gap> large_int_m1 := JuliaEvalString("big(2)^100 - 1");
+gap> N_m1 := JuliaEvalString("big(2)^100 - 1");
 <Julia: 1267650600228229401496703205375>
-gap> large_int_squared := JuliaEvalString("big(2)^200");
+gap> N_squared := JuliaEvalString("big(2)^200");
 <Julia: 1606938044258990275541962092341162602522202993782792835301376>
-gap> large_int_t2 := JuliaEvalString("big(2)^101");
+gap> N_t2 := JuliaEvalString("big(2)^101");
 <Julia: 2535301200456458802993406410752>
 
 #
-gap> zero := Zero(large_int);
+gap> zero := Zero(N);
 <Julia: 0>
-gap> one := One(large_int);
+gap> one := One(N);
 <Julia: 1>
 
 #
-gap> large_int + 1 = large_int_p1;
-true
-gap> 1 + large_int = large_int_p1;
+gap> -N;
+<Julia: -1267650600228229401496703205376>
+
+#
+gap> N + 1;
+<Julia: 1267650600228229401496703205377>
+gap> 1 + N;
+<Julia: 1267650600228229401496703205377>
+gap> N + N;
+<Julia: 2535301200456458802993406410752>
+
+#
+gap> N - 1;
+<Julia: 1267650600228229401496703205375>
+gap> 1 - N;
+<Julia: -1267650600228229401496703205375>
+gap> N - N;
+<Julia: 0>
+
+#
+gap> N * 2;
+<Julia: 2535301200456458802993406410752>
+gap> 2 * N;
+<Julia: 2535301200456458802993406410752>
+gap> N * N = N_squared;
 true
 
 #
-gap> large_int + (-large_int) = zero;
+gap> N^0;
+<Julia: 1>
+gap> N^1;
+<Julia: 1267650600228229401496703205376>
+gap> N^2 = N_squared;
 true
 
 #
-gap> large_int - 1 = large_int_m1;
-true
-
-#
-gap> large_int * 2 = large_int_t2;
-true
-gap> 2 * large_int = large_int_t2;
-true
-gap> large_int * large_int = large_int_squared;
-true
-
-#
-gap> large_int^0 = one;
-true
-gap> large_int^1 = large_int;
-true
-gap> large_int^2 = large_int_squared;
-true
-
-#
-#gap> large_int / large_int = 1;
+#gap> N / N = 1;
 #true
-#gap> large_int / 2^50 = 2^50;
+#gap> N / 2^50 = 2^50;
 #true
 
 #
-#gap> large_int \ large_int = 1;
+#gap> N \ N = 1;
 #true
-#gap> 2^50 \ large_int = 2^50;
+#gap> 2^50 \ N = 2^50;
 #true
 
 #
-gap> large_int < large_int_p1;
-true
-gap> large_int <= large_int_p1;
-true
-gap> large_int > large_int_m1;
-true
-gap> large_int >= large_int_m1;
-true
-gap> large_int = large_int;
-true
+gap> data := [ -N_p1, -N, -N_m1, -1, 0, 1, N_m1, N, N_p1 ];;
+gap> TestBinOp := op -> SetX( [1..Length(data)], [1..Length(data)],
+>                             {i,j} -> op(data[i], data[j]) = op(i,j) );;
+gap> TestBinOp({a,b} -> a < b);
+[ true ]
+gap> TestBinOp({a,b} -> a <= b);
+[ true ]
+gap> TestBinOp({a,b} -> a > b);
+[ true ]
+gap> TestBinOp({a,b} -> a >= b);
+[ true ]
+gap> TestBinOp({a,b} -> a = b);
+[ true ]
 
 #
-#gap> mod(large_int,2) = 0;
-#gap> mod(large_int_p1,2) = 1;
+#gap> mod(N,2) = 0;
+#gap> mod(N_p1,2) = 1;
 
 #
 gap> STOP_TEST( "arith.tst", 1 );


### PR DESCRIPTION
This deliberately ignores the differences between `/` and `//` on the Julia side, just like we did with the `/` and `\` Julia convenience method which call QUO and LQUO. This means that dividing Julia integers produces Julia floats. While GAP users may initially find this confusing, I think it is by far the easiest and least problematic approach to the problem. Any attempts to shoehorn GAP semantics onto Julia objects (e.g. by being "clever" and having `/` in GAP call either Julia's `/` or `//`, depending on the input) IMHO is doomed to failure. 