### PR TITLE
Replace IsGapObj with our own is_gapobj

### DIFF
--- a/JuliaInterface/src/JuliaInterface.h
+++ b/JuliaInterface/src/JuliaInterface.h
@@ -90,6 +90,9 @@ Obj gap_unbox_gapffe(jl_value_t * gapffe);
 //
 int is_gapffe(jl_value_t * v);
 
+//
+int is_gapobj(jl_value_t * v);
+
 // internal
 extern jl_value_t * _ConvertedToJulia_internal(Obj obj);
 

--- a/JuliaInterface/src/convert.c
+++ b/JuliaInterface/src/convert.c
@@ -34,8 +34,8 @@ Obj gap_julia(jl_value_t * julia_obj)
     if (jl_typeis(julia_obj, jl_int64_type)) {
         return ObjInt_Int8(jl_unbox_int64(julia_obj));
     }
-    if (IsGapObj(julia_obj)) {
-        return (Obj)(julia_obj);
+    if (is_gapobj(julia_obj)) {
+        return (Obj)julia_obj;
     }
     if (is_gapffe(julia_obj)) {
         return gap_unbox_gapffe(julia_obj);


### PR DESCRIPTION
Currently, `IsGapObj` stands out from the GAP headers as an
ugly hack. I'd rather remove it from GAP, and have us be self-contained.