### PR TITLE
Make GAP.EvalString more convenient

### DIFF
--- a/LibGAP.jl/src/ccalls.jl
+++ b/LibGAP.jl/src/ccalls.jl
@@ -6,11 +6,16 @@ function GET_FROM_GAP(ptr::Ptr{Cvoid})::Any
     return ccall(:julia_gap,Any,(Ptr{Cvoid},),ptr)
 end
 
-function EvalString( cmd :: String )
+function EvalStringEx( cmd :: String )
     res = ccall( :GAP_EvalString, MPtr, 
                  (Ptr{UInt8},),
                  cmd );
     return res
+end
+
+function EvalString( cmd :: String )
+    res = EvalStringEx(cmd * ";")
+    return res[end][2]
 end
 
 function ValueGlobalVariable( name :: String )

--- a/LibGAP.jl/test/basics.jl
+++ b/LibGAP.jl/test/basics.jl
@@ -33,7 +33,7 @@
 end
 
 @testset "gapcalls" begin
-    f = GAP.EvalString("{x...} -> x;")[1][2]
+    f = GAP.EvalString("{x...} -> x")
     
     @test GAP.julia_to_gap([]) == f()
     @test GAP.julia_to_gap([1]) == f(1)

--- a/LibGAP.jl/test/convenience.jl
+++ b/LibGAP.jl/test/convenience.jl
@@ -2,11 +2,11 @@
 @testset "integer_arithmetics" begin
 
     # Create some large integers
-    large_int = GAP.EvalString( "2^100;" )[1][2]
-    large_int_p1 = GAP.EvalString( "2^100 + 1;" )[1][2]
-    large_int_m1 = GAP.EvalString( "2^100 - 1;" )[1][2]
-    large_int_squared = GAP.EvalString( "2^200;" )[1][2]
-    large_int_t2 = GAP.EvalString( "2^101;" )[1][2]
+    large_int = GAP.EvalString( "2^100" )
+    large_int_p1 = GAP.EvalString( "2^100 + 1" )
+    large_int_m1 = GAP.EvalString( "2^100 - 1" )
+    large_int_squared = GAP.EvalString( "2^200" )
+    large_int_t2 = GAP.EvalString( "2^101" )
 
     @test zero(large_int) == 0
     @test one(large_int) == 1
@@ -42,9 +42,9 @@ end
 
 @testset "ffe_arithmetics" begin
 
-    z3_gen = GAP.EvalString( "Z(3);" )[1][2]
-    z3_one = GAP.EvalString( "Z(3)^0;" )[1][2]
-    z3_zero = GAP.EvalString( "0 * Z(3);" )[1][2]
+    z3_gen = GAP.EvalString( "Z(3)" )
+    z3_one = GAP.EvalString( "Z(3)^0" )
+    z3_zero = GAP.EvalString( "0 * Z(3)" )
 
     z3 = GAP.Globals.Z(3)
 
@@ -60,9 +60,9 @@ end
 end
 
 @testset "object_access" begin
-    list = GAP.EvalString( "[1,2,3];" )[1][2]
-    matrix = GAP.EvalString( "[[1,2],[3,4]];" )[1][2]
-    record = GAP.EvalString( "rec( one := 1 );" )[1][2]
+    list = GAP.EvalString( "[1,2,3]" )
+    matrix = GAP.EvalString( "[[1,2],[3,4]]" )
+    record = GAP.EvalString( "rec( one := 1 )" )
 
     @test length(list) == 3
     @test list[1] == 1

--- a/LibGAP.jl/test/conversion.jl
+++ b/LibGAP.jl/test/conversion.jl
@@ -20,49 +20,49 @@
 
     ## BigInts
     @test GAP.gap_to_julia(BigInt,1) == BigInt(1)
-    x = GAP.EvalString("2^100;")[1][2]
+    x = GAP.EvalString("2^100")
     @test GAP.gap_to_julia(BigInt,x) == BigInt(2)^100
     @test GAP.gap_to_julia(x) == BigInt(2)^100
-    x = GAP.EvalString("1/2;")[1][2]
+    x = GAP.EvalString("1/2")
     @test_throws ArgumentError GAP.gap_to_julia(BigInt,x)
 
     ## Rationals
     @test GAP.gap_to_julia(Rational{Int64},1) == 1//1
-    x = GAP.EvalString("2^100;")[1][2]
+    x = GAP.EvalString("2^100")
     @test GAP.gap_to_julia(Rational{BigInt},x) == BigInt(2)^100 // 1
-    x = GAP.EvalString("2^100/3;")[1][2]
+    x = GAP.EvalString("2^100/3")
     @test GAP.gap_to_julia(Rational{BigInt},x) == BigInt(2)^100 // 3
     @test GAP.gap_to_julia(x) == BigInt(2)^100 // 3
-    x = GAP.EvalString("(1,2,3);")[1][2]
+    x = GAP.EvalString("(1,2,3)")
     @test_throws ArgumentError GAP.gap_to_julia(Rational{BigInt},x)
 
     ## Floats
-    x = GAP.EvalString("2.;")[1][2]
+    x = GAP.EvalString("2.")
     @test GAP.gap_to_julia(Float64,x) == 2.
     @test GAP.gap_to_julia(x) == 2.
     @test GAP.gap_to_julia(Float32,x) == Float32(2.)
     @test GAP.gap_to_julia(Float16,x) == Float16(2.)
     @test GAP.gap_to_julia(BigFloat,x) == BigFloat(2.)
-    x = GAP.EvalString("(1,2,3);")[1][2]
+    x = GAP.EvalString("(1,2,3)")
     @test_throws ArgumentError GAP.gap_to_julia(Float64,x)
 
     ## Chars
-    x = GAP.EvalString("'x';")[1][2]
+    x = GAP.EvalString("'x'")
     @test GAP.gap_to_julia(Cuchar,x) == Cuchar('x')
     @test GAP.gap_to_julia(x) == Cuchar('x')
-    x = GAP.EvalString("(1,2,3);")[1][2]
+    x = GAP.EvalString("(1,2,3)")
     @test_throws ArgumentError GAP.gap_to_julia(Cuchar,x)
 
     ## Strings & Symbols
-    x = GAP.EvalString("\"foo\";")[1][2]
+    x = GAP.EvalString("\"foo\"")
     @test GAP.gap_to_julia(AbstractString,x) == "foo"
     @test GAP.gap_to_julia(x) == "foo"
     @test GAP.gap_to_julia(Symbol,x) == :foo
-    x = GAP.EvalString("(1,2,3);")[1][2]
+    x = GAP.EvalString("(1,2,3)")
     @test_throws ArgumentError GAP.gap_to_julia(AbstractString,x)
-    x = GAP.EvalString("\"foo\";")[1][2]
+    x = GAP.EvalString("\"foo\"")
     @test GAP.gap_to_julia(Array{UInt8,1},x) == UInt8[0x66,0x6f,0x6f]
-    x = GAP.EvalString("[1,2,3];")[1][2]
+    x = GAP.EvalString("[1,2,3]")
     @test GAP.gap_to_julia(Array{UInt8,1},x) == UInt8[1,2,3]
 
     ## Arrays
@@ -75,17 +75,17 @@
     @test GAP.gap_to_julia(Tuple{Int64,Any,Int32},x) == Tuple{Int64,Any,Int32}([1,2,3])
     
     ## Dictionaries
-    x = GAP.EvalString(" rec( foo := 1, bar := \"foo\" );" )[1][2]
+    x = GAP.EvalString(" rec( foo := 1, bar := \"foo\" )" )
     y = Dict{Symbol,Any}( :foo => 1, :bar => "foo" )
     @test GAP.gap_to_julia(Dict{Symbol,Any},x) == y
     @test GAP.gap_to_julia(x) == y
 
     ## Default
-    x = GAP.EvalString("(1,2,3);")[1][2]
+    x = GAP.EvalString("(1,2,3)")
     @test GAP.gap_to_julia(x) == x
 
     ## Recursive conversions
-    xx = GAP.EvalString("l:=[1];x:=[l,l];")[2][2]
+    xx = GAP.EvalString("l:=[1];x:=[l,l];")
     conv = GAP.gap_to_julia(xx)
     @test conv[1] === conv[2]
     conv = GAP.gap_to_julia(Tuple{Tuple{Int64},Tuple{Int64}},xx)
@@ -114,61 +114,58 @@ end
 
     ## BigInts
     @test GAP.julia_to_gap(BigInt(1)) == 1
-    x = GAP.EvalString("2^100;")[1][2]
+    x = GAP.EvalString("2^100")
     @test GAP.julia_to_gap(BigInt(2)^100) == x
 
     ## Rationals
-    x = GAP.EvalString("2^100;")[1][2]
+    x = GAP.EvalString("2^100")
     @test GAP.julia_to_gap(Rational{BigInt}(2)^100 // 1) == x
-    x = GAP.EvalString("2^100/3;")[1][2]
+    x = GAP.EvalString("2^100/3")
     @test GAP.julia_to_gap(Rational{BigInt}(2)^100 // 3) == x
     @test GAP.julia_to_gap(Rational{Int64}(1) // 0) == GAP.Globals.infinity
 
     ## Floats
-    x = GAP.EvalString("2.;")[1][2]
+    x = GAP.EvalString("2.")
     @test GAP.julia_to_gap(2.) == x
     @test GAP.julia_to_gap(Float32(2.)) == x
     @test GAP.julia_to_gap(Float16(2.)) == x
 
     ## Chars
-    x = GAP.EvalString("'x';")[1][2]
+    x = GAP.EvalString("'x'")
     @test GAP.julia_to_gap('x') == x
 
     ## Strings & Symbols
-    x = GAP.EvalString("\"foo\";")[1][2]
+    x = GAP.EvalString("\"foo\"")
     @test GAP.julia_to_gap("foo") == x
     @test GAP.julia_to_gap(:foo) == x
 
     ## Arrays
-    x = GAP.EvalString("[1,\"foo\",2];")[1][2]
+    x = GAP.EvalString("[1,\"foo\",2]")
     @test GAP.julia_to_gap([1,"foo",BigInt(2)],Val(true)) == x
-    x = GAP.EvalString("[1,JuliaEvalString(\"\\\"foo\\\"\"),2];")[1][2]
+    x = GAP.EvalString("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
     @test GAP.julia_to_gap([1,"foo",BigInt(2)]) == x
     
     ## Tuples
-    x = GAP.EvalString("[1,\"foo\",2];")[1][2]
+    x = GAP.EvalString("[1,\"foo\",2]")
     @test GAP.julia_to_gap((1,"foo",2),Val(true)) == x
-    x = GAP.EvalString("[1,JuliaEvalString(\"\\\"foo\\\"\"),2];")[1][2]
+    x = GAP.EvalString("[1,JuliaEvalString(\"\\\"foo\\\"\"),2]")
     @test GAP.julia_to_gap((1,"foo",2)) == x
     
     ## Dictionaries
-    x = GAP.EvalString(" rec( foo := 1, bar := \"foo\" );" )[1][2]
+    x = GAP.EvalString(" rec( foo := 1, bar := \"foo\" )" )
     y = Dict{Symbol,Any}( :foo => 1, :bar => "foo" )
     @test GAP.julia_to_gap(y,Val(true)) == x
-    x = GAP.EvalString(" rec( foo := 1, bar := JuliaEvalString(\"\\\"foo\\\"\") );" )[1][2]
+    x = GAP.EvalString(" rec( foo := 1, bar := JuliaEvalString(\"\\\"foo\\\"\") )" )
     @test GAP.julia_to_gap(y) == x
 
     ## Recursive conversions
     l = [1]
     yy = [l,l]
-    xx = GAP.EvalString("l:=[1];x:=[l,l];")[2][2]
+    xx = GAP.EvalString("l:=[1];x:=[l,l];")
     conv = GAP.julia_to_gap(xx)
     @test GAP.Globals.IsIdenticalObj(conv[1],conv[2])
-    ## FIXME: This test is broken because of
-    ##        infinite recursion in ViewString
-    # l = Any[1]
-    # l[1] = l
-    # xx = GAP.EvalString("l:=[];l[1]:=l;")[1][2];
-    # @test GAP.julia_to_gap(l) == xx
+
+    xx = GAP.EvalString("[~]");
+    @test xx === xx[1]
 
 end


### PR DESCRIPTION
Rename the current GAP.EvalString to GAP.EvalStringEx (for "Ex"tended), added
a new GAP.EvalString which only returns the value of the last command, and
which also automatically appends a semicolon to the input string.