### PR TITLE
Rename GAP.GAPObj -> GAP.Obj; GAP.GapFFE -> GAP.FFE

### DIFF
--- a/JuliaInterface/gap/calls.gi
+++ b/JuliaInterface/gap/calls.gi
@@ -1,4 +1,4 @@
-BindGlobal("_JL_Array_GAPObj_1", JuliaEvalString("Array{GAP.GAPObj,1}"));
+BindGlobal("_JL_Array_GAPObj_1", JuliaEvalString("Array{GAP.Obj,1}"));
 
 ##
 ##  We want to use &GAP's function call syntax also for certain Julia objects

--- a/JuliaInterface/src/JuliaInterface.c
+++ b/JuliaInterface/src/JuliaInterface.c
@@ -55,7 +55,9 @@ Obj Func_JULIAINTERFACE_INTERNAL_INIT(Obj self)
 {
     jl_module_t * gap_module = get_module_from_string("GAP");
     JULIA_GAPFFE_type =
-        (jl_datatype_t *)jl_get_global(gap_module, jl_symbol("GapFFE"));
+        (jl_datatype_t *)jl_get_global(gap_module, jl_symbol("FFE"));
+    if (!JULIA_GAPFFE_type)
+        ErrorMayQuit("Could not locate the GAP.FFE datatype", 0, 0);
     return NULL;
 }
 

--- a/JuliaInterface/tst/utils.tst
+++ b/JuliaInterface/tst/utils.tst
@@ -39,7 +39,7 @@ gap> Julia.Core.Tuple( GAPToJulia( JuliaEvalString( "Array{Any,1}" ), [] ) );
 <Julia: ()>
 gap> Julia.Core.Tuple( GAPToJulia( JuliaEvalString( "Array{Any,1}" ), [1] ) );
 <Julia: (1,)>
-gap> Julia.Core.Tuple( GAPToJulia( JuliaEvalString( "Array{GAP.GAPObj,1}" ), [1,true,fail] ));
+gap> Julia.Core.Tuple( GAPToJulia( JuliaEvalString( "Array{GAP.Obj,1}" ), [1,true,fail] ));
 <Julia: (1, true, GAP: fail)>
 gap> Julia.Core.Tuple(1);
 <Julia: (1,)>

--- a/LibGAP.jl/src/gap.jl
+++ b/LibGAP.jl/src/gap.jl
@@ -3,18 +3,18 @@ import Base: convert, getindex, setindex!, length, show
 const True = GAP.Globals.ReturnTrue()
 const False = GAP.Globals.ReturnFalse()
 
-const GAPInputType_internal = Union{MPtr,GAP.GapFFE}
+const GAPInputType_internal = Union{MPtr,FFE}
 const GAPInputType = Union{GAPInputType_internal,Int64,Bool}
 
-const GAPObj = Union{GAPInputType,Nothing}
+const Obj = Union{GAPInputType,Nothing}
 
-function Base.show( io::IO, obj::Union{MPtr,GAP.GapFFE} )
+function Base.show( io::IO, obj::Union{MPtr,FFE} )
     str = GAP.Globals.String( obj )
     stri = CSTR_STRING( str )
     print(io,"GAP: $stri")
 end
 
-function Base.string( obj::Union{MPtr,GAP.GapFFE} )
+function Base.string( obj::Union{MPtr,FFE} )
     str = GAP.Globals.String( obj )
     return CSTR_STRING( str )
 end

--- a/LibGAP.jl/src/gap_to_julia.jl
+++ b/LibGAP.jl/src/gap_to_julia.jl
@@ -109,7 +109,7 @@ function gap_to_julia( ::Type{Array{UInt8,1}}, obj :: MPtr )
 end
 
 ## Arrays
-function gap_to_julia( ::Type{Array{GAPObj,1}}, obj :: MPtr , recursion_dict = IdDict() )
+function gap_to_julia( ::Type{Array{Obj,1}}, obj :: MPtr , recursion_dict = IdDict() )
     if ! Globals.IsList( obj )
         throw(ArgumentError("<obj> is not a list"))
     end
@@ -158,7 +158,7 @@ function gap_to_julia( ::Type{T}, obj::MPtr, recursion_dict = IdDict() ) where T
     if ! Globals.IsList(obj)
         throw(ArgumentError("<obj> is not a list"))
     end
-    list_translated = gap_to_julia(Array{GAPObj,1},obj)
+    list_translated = gap_to_julia(Array{Obj,1},obj)
     parameters = T.parameters
     list = Array{Any,1}(undef,length(parameters))
     for i in 1:length(parameters)

--- a/LibGAP.jl/src/initialization.jl
+++ b/LibGAP.jl/src/initialization.jl
@@ -8,9 +8,9 @@ module GAP
 > This type is defined in the JuliaInterface C code.
 """
 
-primitive type GapFFE 64 end
+primitive type FFE 64 end
 
-export GapFFE
+export FFE
 
 import Base: length, convert, finalize
 


### PR DESCRIPTION
Also add a paranoia check to _JULIAINTERFACE_INTERNAL_INIT and
abort if GAP.FFE cannot be found (say, because you forgot to
recompile the kernel extension...)

Resolves #161