### PR TITLE
JuliaFunction: set name and "location" of the function

### DIFF
--- a/JuliaInterface/tst/utils.tst
+++ b/JuliaInterface/tst/utils.tst
@@ -101,4 +101,12 @@ gap> JuliaGetFieldOfObject(JuliaModule("Base"), "not-a-field");
 Error, type Module has no field not-a-field
 
 ##
+gap> NameFunction(Julia.Base.parse);
+"parse"
+gap> Display(Julia.Base.parse);
+function ( arg... )
+    <<kernel code>> from Julia:parse
+end
+
+##
 gap> STOP_TEST( "utils.tst", 1 );


### PR DESCRIPTION
The latter means that using `Display` on a GAP function produced via
`JuliaFunction` will at least give some indication about where the function
comes from. It's not perfect, but certainly better than nothing (= what we
currently get).